### PR TITLE
Testing import comments process on non-generic collections

### DIFF
--- a/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/ArrayList.cs
@@ -31,6 +31,8 @@ namespace System.Collections
 #if FEATURE_NETCORE
     [FriendAccessAllowed]
 #endif
+    /// <summary>Implements the <see cref="T:System.Collections.IList" /> interface using an array whose size is dynamically increased as required.To browse the .NET Framework source code for this type, see the Reference Source.</summary>
+    /// <filterpriority>1</filterpriority>
     [DebuggerTypeProxy(typeof(System.Collections.ArrayList.ArrayListDebugView))]
     [DebuggerDisplay("Count = {Count}")]
     public class ArrayList : IList
@@ -55,6 +57,7 @@ namespace System.Collections
         // Constructs a ArrayList. The list is initially empty and has a capacity
         // of zero. Upon adding the first element to the list the capacity is
         // increased to _defaultCapacity, and then increased in multiples of two as required.
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.ArrayList" /> class that is empty and has the default initial capacity.</summary>
         public ArrayList()
         {
             _items = Array.Empty<Object>();
@@ -64,6 +67,9 @@ namespace System.Collections
         // initially empty, but will have room for the given number of elements
         // before any reallocations are required.
         // 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.ArrayList" /> class that is empty and has the specified initial capacity.</summary>
+        /// <param name="capacity">The number of elements that the new list can initially store. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="capacity" /> is less than zero. </exception>
         public ArrayList(int capacity)
         {
             if (capacity < 0) throw new ArgumentOutOfRangeException(nameof(capacity), SR.Format(SR.ArgumentOutOfRange_MustBeNonNegNum, "capacity"));
@@ -79,6 +85,9 @@ namespace System.Collections
         // size and capacity of the new list will both be equal to the size of the
         // given collection.
         // 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.ArrayList" /> class that contains elements copied from the specified collection and that has the same initial capacity as the number of elements copied.</summary>
+        /// <param name="c">The <see cref="T:System.Collections.ICollection" /> whose elements are copied to the new list. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="c" /> is null. </exception>
         public ArrayList(ICollection c)
         {
             if (c == null)
@@ -101,6 +110,11 @@ namespace System.Collections
         // the internal array used to hold items.  When set, the internal 
         // array of the list is reallocated to the given capacity.
         // 
+        /// <summary>Gets or sets the number of elements that the <see cref="T:System.Collections.ArrayList" /> can contain.</summary>
+        /// <returns>The number of elements that the <see cref="T:System.Collections.ArrayList" /> can contain.</returns>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><see cref="P:System.Collections.ArrayList.Capacity" /> is set to a value that is less than <see cref="P:System.Collections.ArrayList.Count" />.</exception>
+        /// <exception cref="T:System.OutOfMemoryException">There is not enough memory available on the system.</exception>
+        /// <filterpriority>1</filterpriority>
         public virtual int Capacity
         {
             get
@@ -138,6 +152,9 @@ namespace System.Collections
         }
 
         // Read-only property describing how many elements are in the List.
+        /// <summary>Gets the number of elements actually contained in the <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <returns>The number of elements actually contained in the <see cref="T:System.Collections.ArrayList" />.</returns>
+        /// <filterpriority>1</filterpriority>
         public virtual int Count
         {
             get
@@ -147,6 +164,9 @@ namespace System.Collections
             }
         }
 
+        /// <summary>Gets a value indicating whether the <see cref="T:System.Collections.ArrayList" /> has a fixed size.</summary>
+        /// <returns>true if the <see cref="T:System.Collections.ArrayList" /> has a fixed size; otherwise, false. The default is false.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual bool IsFixedSize
         {
             get { return false; }
@@ -154,18 +174,27 @@ namespace System.Collections
 
 
         // Is this ArrayList read-only?
+        /// <summary>Gets a value indicating whether the <see cref="T:System.Collections.ArrayList" /> is read-only.</summary>
+        /// <returns>true if the <see cref="T:System.Collections.ArrayList" /> is read-only; otherwise, false. The default is false.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual bool IsReadOnly
         {
             get { return false; }
         }
 
         // Is this ArrayList synchronized (thread-safe)?
+        /// <summary>Gets a value indicating whether access to the <see cref="T:System.Collections.ArrayList" /> is synchronized (thread safe).</summary>
+        /// <returns>true if access to the <see cref="T:System.Collections.ArrayList" /> is synchronized (thread safe); otherwise, false. The default is false.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual bool IsSynchronized
         {
             get { return false; }
         }
 
         // Synchronization root for this object.
+        /// <summary>Gets an object that can be used to synchronize access to the <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <returns>An object that can be used to synchronize access to the <see cref="T:System.Collections.ArrayList" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual Object SyncRoot
         {
             get
@@ -180,6 +209,11 @@ namespace System.Collections
 
         // Sets or Gets the element at the given index.
         // 
+        /// <summary>Gets or sets the element at the specified index.</summary>
+        /// <returns>The element at the specified index.</returns>
+        /// <param name="index">The zero-based index of the element to get or set. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero.-or- <paramref name="index" /> is equal to or greater than <see cref="P:System.Collections.ArrayList.Count" />. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual Object this[int index]
         {
             get
@@ -205,6 +239,11 @@ namespace System.Collections
         // However, since these methods are generic, the performance may not be
         // nearly as good for some operations as they would be on the IList itself.
         //
+        /// <summary>Creates an <see cref="T:System.Collections.ArrayList" /> wrapper for a specific <see cref="T:System.Collections.IList" />.</summary>
+        /// <returns>The <see cref="T:System.Collections.ArrayList" /> wrapper around the <see cref="T:System.Collections.IList" />.</returns>
+        /// <param name="list">The <see cref="T:System.Collections.IList" /> to wrap.</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="list" /> is null.</exception>
+        /// <filterpriority>2</filterpriority>
         public static ArrayList Adapter(IList list)
         {
             if (list == null)
@@ -218,6 +257,11 @@ namespace System.Collections
         // increased by one. If required, the capacity of the list is doubled
         // before adding the new element.
         //
+        /// <summary>Adds an object to the end of the <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <returns>The <see cref="T:System.Collections.ArrayList" /> index at which the <paramref name="value" /> has been added.</returns>
+        /// <param name="value">The <see cref="T:System.Object" /> to be added to the end of the <see cref="T:System.Collections.ArrayList" />. The value can be null. </param>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only.-or- The <see cref="T:System.Collections.ArrayList" /> has a fixed size. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual int Add(Object value)
         {
             Contract.Ensures(Contract.Result<int>() >= 0);
@@ -231,6 +275,11 @@ namespace System.Collections
         // required, the capacity of the list is increased to twice the previous
         // capacity or the new size, whichever is larger.
         //
+        /// <summary>Adds the elements of an <see cref="T:System.Collections.ICollection" /> to the end of the <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <param name="c">The <see cref="T:System.Collections.ICollection" /> whose elements should be added to the end of the <see cref="T:System.Collections.ArrayList" />. The collection itself cannot be null, but it can contain elements that are null. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="c" /> is null. </exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only.-or- The <see cref="T:System.Collections.ArrayList" /> has a fixed size. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual void AddRange(ICollection c)
         {
             InsertRange(_size, c);
@@ -256,6 +305,16 @@ namespace System.Collections
         // The method uses the Array.BinarySearch method to perform the
         // search.
         // 
+        /// <summary>Searches a range of elements in the sorted <see cref="T:System.Collections.ArrayList" /> for an element using the specified comparer and returns the zero-based index of the element.</summary>
+        /// <returns>The zero-based index of <paramref name="value" /> in the sorted <see cref="T:System.Collections.ArrayList" />, if <paramref name="value" /> is found; otherwise, a negative number, which is the bitwise complement of the index of the next element that is larger than <paramref name="value" /> or, if there is no larger element, the bitwise complement of <see cref="P:System.Collections.ArrayList.Count" />.</returns>
+        /// <param name="index">The zero-based starting index of the range to search. </param>
+        /// <param name="count">The length of the range to search. </param>
+        /// <param name="value">The <see cref="T:System.Object" /> to locate. The value can be null. </param>
+        /// <param name="comparer">The <see cref="T:System.Collections.IComparer" /> implementation to use when comparing elements.-or- null to use the default comparer that is the <see cref="T:System.IComparable" /> implementation of each element. </param>
+        /// <exception cref="T:System.ArgumentException"><paramref name="index" /> and <paramref name="count" /> do not denote a valid range in the <see cref="T:System.Collections.ArrayList" />.-or- <paramref name="comparer" /> is null and neither <paramref name="value" /> nor the elements of <see cref="T:System.Collections.ArrayList" /> implement the <see cref="T:System.IComparable" /> interface. </exception>
+        /// <exception cref="T:System.InvalidOperationException"><paramref name="comparer" /> is null and <paramref name="value" /> is not of the same type as the elements of the <see cref="T:System.Collections.ArrayList" />. </exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero.-or- <paramref name="count" /> is less than zero. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual int BinarySearch(int index, int count, Object value, IComparer comparer)
         {
             if (index < 0)
@@ -271,12 +330,25 @@ namespace System.Collections
             return Array.BinarySearch((Array)_items, index, count, value, comparer);
         }
 
+        /// <summary>Searches the entire sorted <see cref="T:System.Collections.ArrayList" /> for an element using the default comparer and returns the zero-based index of the element.</summary>
+        /// <returns>The zero-based index of <paramref name="value" /> in the sorted <see cref="T:System.Collections.ArrayList" />, if <paramref name="value" /> is found; otherwise, a negative number, which is the bitwise complement of the index of the next element that is larger than <paramref name="value" /> or, if there is no larger element, the bitwise complement of <see cref="P:System.Collections.ArrayList.Count" />.</returns>
+        /// <param name="value">The <see cref="T:System.Object" /> to locate. The value can be null. </param>
+        /// <exception cref="T:System.ArgumentException">Neither <paramref name="value" /> nor the elements of <see cref="T:System.Collections.ArrayList" /> implement the <see cref="T:System.IComparable" /> interface. </exception>
+        /// <exception cref="T:System.InvalidOperationException"><paramref name="value" /> is not of the same type as the elements of the <see cref="T:System.Collections.ArrayList" />. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual int BinarySearch(Object value)
         {
             Contract.Ensures(Contract.Result<int>() < Count);
             return BinarySearch(0, Count, value, null);
         }
 
+        /// <summary>Searches the entire sorted <see cref="T:System.Collections.ArrayList" /> for an element using the specified comparer and returns the zero-based index of the element.</summary>
+        /// <returns>The zero-based index of <paramref name="value" /> in the sorted <see cref="T:System.Collections.ArrayList" />, if <paramref name="value" /> is found; otherwise, a negative number, which is the bitwise complement of the index of the next element that is larger than <paramref name="value" /> or, if there is no larger element, the bitwise complement of <see cref="P:System.Collections.ArrayList.Count" />.</returns>
+        /// <param name="value">The <see cref="T:System.Object" /> to locate. The value can be null. </param>
+        /// <param name="comparer">The <see cref="T:System.Collections.IComparer" /> implementation to use when comparing elements.-or- null to use the default comparer that is the <see cref="T:System.IComparable" /> implementation of each element. </param>
+        /// <exception cref="T:System.ArgumentException"><paramref name="comparer" /> is null and neither <paramref name="value" /> nor the elements of <see cref="T:System.Collections.ArrayList" /> implement the <see cref="T:System.IComparable" /> interface. </exception>
+        /// <exception cref="T:System.InvalidOperationException"><paramref name="comparer" /> is null and <paramref name="value" /> is not of the same type as the elements of the <see cref="T:System.Collections.ArrayList" />. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual int BinarySearch(Object value, IComparer comparer)
         {
             Contract.Ensures(Contract.Result<int>() < Count);
@@ -285,6 +357,9 @@ namespace System.Collections
 
 
         // Clears the contents of ArrayList.
+        /// <summary>Removes all elements from the <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only.-or- The <see cref="T:System.Collections.ArrayList" /> has a fixed size. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual void Clear()
         {
             if (_size > 0)
@@ -298,6 +373,9 @@ namespace System.Collections
         // Clones this ArrayList, doing a shallow copy.  (A copy is made of all
         // Object references in the ArrayList, but the Objects pointed to 
         // are not cloned).
+        /// <summary>Creates a shallow copy of the <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <returns>A shallow copy of the <see cref="T:System.Collections.ArrayList" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual Object Clone()
         {
             Contract.Ensures(Contract.Result<Object>() != null);
@@ -313,6 +391,10 @@ namespace System.Collections
         // It does a linear, O(n) search.  Equality is determined by calling
         // item.Equals().
         //
+        /// <summary>Determines whether an element is in the <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <returns>true if <paramref name="item" /> is found in the <see cref="T:System.Collections.ArrayList" />; otherwise, false.</returns>
+        /// <param name="item">The <see cref="T:System.Object" /> to locate in the <see cref="T:System.Collections.ArrayList" />. The value can be null. </param>
+        /// <filterpriority>1</filterpriority>
         public virtual bool Contains(Object item)
         {
             if (item == null)
@@ -334,6 +416,12 @@ namespace System.Collections
         // Copies this ArrayList into array, which must be of a 
         // compatible array type.  
         //
+        /// <summary>Copies the entire <see cref="T:System.Collections.ArrayList" /> to a compatible one-dimensional <see cref="T:System.Array" />, starting at the beginning of the target array.</summary>
+        /// <param name="array">The one-dimensional <see cref="T:System.Array" /> that is the destination of the elements copied from <see cref="T:System.Collections.ArrayList" />. The <see cref="T:System.Array" /> must have zero-based indexing. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="array" /> is null. </exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="array" /> is multidimensional.-or- The number of elements in the source <see cref="T:System.Collections.ArrayList" /> is greater than the number of elements that the destination <paramref name="array" /> can contain. </exception>
+        /// <exception cref="T:System.InvalidCastException">The type of the source <see cref="T:System.Collections.ArrayList" /> cannot be cast automatically to the type of the destination <paramref name="array" />. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void CopyTo(Array array)
         {
             CopyTo(array, 0);
@@ -342,6 +430,14 @@ namespace System.Collections
         // Copies this ArrayList into array, which must be of a 
         // compatible array type.  
         //
+        /// <summary>Copies the entire <see cref="T:System.Collections.ArrayList" /> to a compatible one-dimensional <see cref="T:System.Array" />, starting at the specified index of the target array.</summary>
+        /// <param name="array">The one-dimensional <see cref="T:System.Array" /> that is the destination of the elements copied from <see cref="T:System.Collections.ArrayList" />. The <see cref="T:System.Array" /> must have zero-based indexing. </param>
+        /// <param name="arrayIndex">The zero-based index in <paramref name="array" /> at which copying begins. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="array" /> is null. </exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="arrayIndex" /> is less than zero. </exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="array" /> is multidimensional.-or- The number of elements in the source <see cref="T:System.Collections.ArrayList" /> is greater than the available space from <paramref name="arrayIndex" /> to the end of the destination <paramref name="array" />. </exception>
+        /// <exception cref="T:System.InvalidCastException">The type of the source <see cref="T:System.Collections.ArrayList" /> cannot be cast automatically to the type of the destination <paramref name="array" />. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void CopyTo(Array array, int arrayIndex)
         {
             if ((array != null) && (array.Rank != 1))
@@ -355,6 +451,16 @@ namespace System.Collections
         // 
         // The method uses the Array.Copy method to copy the elements.
         // 
+        /// <summary>Copies a range of elements from the <see cref="T:System.Collections.ArrayList" /> to a compatible one-dimensional <see cref="T:System.Array" />, starting at the specified index of the target array.</summary>
+        /// <param name="index">The zero-based index in the source <see cref="T:System.Collections.ArrayList" /> at which copying begins. </param>
+        /// <param name="array">The one-dimensional <see cref="T:System.Array" /> that is the destination of the elements copied from <see cref="T:System.Collections.ArrayList" />. The <see cref="T:System.Array" /> must have zero-based indexing. </param>
+        /// <param name="arrayIndex">The zero-based index in <paramref name="array" /> at which copying begins. </param>
+        /// <param name="count">The number of elements to copy. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="array" /> is null. </exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero.-or- <paramref name="arrayIndex" /> is less than zero.-or- <paramref name="count" /> is less than zero. </exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="array" /> is multidimensional.-or- <paramref name="index" /> is equal to or greater than the <see cref="P:System.Collections.ArrayList.Count" /> of the source <see cref="T:System.Collections.ArrayList" />.-or- The number of elements from <paramref name="index" /> to the end of the source <see cref="T:System.Collections.ArrayList" /> is greater than the available space from <paramref name="arrayIndex" /> to the end of the destination <paramref name="array" />. </exception>
+        /// <exception cref="T:System.InvalidCastException">The type of the source <see cref="T:System.Collections.ArrayList" /> cannot be cast automatically to the type of the destination <paramref name="array" />. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void CopyTo(int index, Array array, int arrayIndex, int count)
         {
             if (_size - index < count)
@@ -386,6 +492,11 @@ namespace System.Collections
         // Returns a list wrapper that is fixed at the current size.  Operations
         // that add or remove items will fail, however, replacing items is allowed.
         //
+        /// <summary>Returns an <see cref="T:System.Collections.IList" /> wrapper with a fixed size.</summary>
+        /// <returns>An <see cref="T:System.Collections.IList" /> wrapper with a fixed size.</returns>
+        /// <param name="list">The <see cref="T:System.Collections.IList" /> to wrap. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="list" /> is null. </exception>
+        /// <filterpriority>2</filterpriority>
         public static IList FixedSize(IList list)
         {
             if (list == null)
@@ -398,6 +509,11 @@ namespace System.Collections
         // Returns a list wrapper that is fixed at the current size.  Operations
         // that add or remove items will fail, however, replacing items is allowed.
         //
+        /// <summary>Returns an <see cref="T:System.Collections.ArrayList" /> wrapper with a fixed size.</summary>
+        /// <returns>An <see cref="T:System.Collections.ArrayList" /> wrapper with a fixed size.</returns>
+        /// <param name="list">The <see cref="T:System.Collections.ArrayList" /> to wrap. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="list" /> is null. </exception>
+        /// <filterpriority>2</filterpriority>
         public static ArrayList FixedSize(ArrayList list)
         {
             if (list == null)
@@ -412,6 +528,9 @@ namespace System.Collections
         // while an enumeration is in progress, the MoveNext and 
         // GetObject methods of the enumerator will throw an exception.
         //
+        /// <summary>Returns an enumerator for the entire <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> for the entire <see cref="T:System.Collections.ArrayList" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual IEnumerator GetEnumerator()
         {
             Contract.Ensures(Contract.Result<IEnumerator>() != null);
@@ -423,6 +542,13 @@ namespace System.Collections
         // while an enumeration is in progress, the MoveNext and 
         // GetObject methods of the enumerator will throw an exception.
         //
+        /// <summary>Returns an enumerator for a range of elements in the <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> for the specified range of elements in the <see cref="T:System.Collections.ArrayList" />.</returns>
+        /// <param name="index">The zero-based starting index of the <see cref="T:System.Collections.ArrayList" /> section that the enumerator should refer to. </param>
+        /// <param name="count">The number of elements in the <see cref="T:System.Collections.ArrayList" /> section that the enumerator should refer to. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero.-or- <paramref name="count" /> is less than zero. </exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="index" /> and <paramref name="count" /> do not specify a valid range in the <see cref="T:System.Collections.ArrayList" />. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual IEnumerator GetEnumerator(int index, int count)
         {
             if (index < 0)
@@ -445,6 +571,10 @@ namespace System.Collections
         // This method uses the Array.IndexOf method to perform the
         // search.
         // 
+        /// <summary>Searches for the specified <see cref="T:System.Object" /> and returns the zero-based index of the first occurrence within the entire <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <returns>The zero-based index of the first occurrence of <paramref name="value" /> within the entire <see cref="T:System.Collections.ArrayList" />, if found; otherwise, -1.</returns>
+        /// <param name="value">The <see cref="T:System.Object" /> to locate in the <see cref="T:System.Collections.ArrayList" />. The value can be null. </param>
+        /// <filterpriority>1</filterpriority>
         public virtual int IndexOf(Object value)
         {
             Contract.Ensures(Contract.Result<int>() < Count);
@@ -460,6 +590,12 @@ namespace System.Collections
         // This method uses the Array.IndexOf method to perform the
         // search.
         // 
+        /// <summary>Searches for the specified <see cref="T:System.Object" /> and returns the zero-based index of the first occurrence within the range of elements in the <see cref="T:System.Collections.ArrayList" /> that extends from the specified index to the last element.</summary>
+        /// <returns>The zero-based index of the first occurrence of <paramref name="value" /> within the range of elements in the <see cref="T:System.Collections.ArrayList" /> that extends from <paramref name="startIndex" /> to the last element, if found; otherwise, -1.</returns>
+        /// <param name="value">The <see cref="T:System.Object" /> to locate in the <see cref="T:System.Collections.ArrayList" />. The value can be null. </param>
+        /// <param name="startIndex">The zero-based starting index of the search. 0 (zero) is valid in an empty list.</param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="startIndex" /> is outside the range of valid indexes for the <see cref="T:System.Collections.ArrayList" />. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual int IndexOf(Object value, int startIndex)
         {
             if (startIndex > _size)
@@ -478,6 +614,13 @@ namespace System.Collections
         // This method uses the Array.IndexOf method to perform the
         // search.
         // 
+        /// <summary>Searches for the specified <see cref="T:System.Object" /> and returns the zero-based index of the first occurrence within the range of elements in the <see cref="T:System.Collections.ArrayList" /> that starts at the specified index and contains the specified number of elements.</summary>
+        /// <returns>The zero-based index of the first occurrence of <paramref name="value" /> within the range of elements in the <see cref="T:System.Collections.ArrayList" /> that starts at <paramref name="startIndex" /> and contains <paramref name="count" /> number of elements, if found; otherwise, -1.</returns>
+        /// <param name="value">The <see cref="T:System.Object" /> to locate in the <see cref="T:System.Collections.ArrayList" />. The value can be null. </param>
+        /// <param name="startIndex">The zero-based starting index of the search. 0 (zero) is valid in an empty list.</param>
+        /// <param name="count">The number of elements in the section to search. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="startIndex" /> is outside the range of valid indexes for the <see cref="T:System.Collections.ArrayList" />.-or- <paramref name="count" /> is less than zero.-or- <paramref name="startIndex" /> and <paramref name="count" /> do not specify a valid section in the <see cref="T:System.Collections.ArrayList" />. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual int IndexOf(Object value, int startIndex, int count)
         {
             if (startIndex > _size)
@@ -492,6 +635,12 @@ namespace System.Collections
         // is increased by one. If required, the capacity of the list is doubled
         // before inserting the new element.
         // 
+        /// <summary>Inserts an element into the <see cref="T:System.Collections.ArrayList" /> at the specified index.</summary>
+        /// <param name="index">The zero-based index at which <paramref name="value" /> should be inserted. </param>
+        /// <param name="value">The <see cref="T:System.Object" /> to insert. The value can be null. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero.-or- <paramref name="index" /> is greater than <see cref="P:System.Collections.ArrayList.Count" />. </exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only.-or- The <see cref="T:System.Collections.ArrayList" /> has a fixed size. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual void Insert(int index, Object value)
         {
             // Note that insertions at the end are legal.
@@ -514,6 +663,13 @@ namespace System.Collections
         // capacity or the new size, whichever is larger.  Ranges may be added
         // to the end of the list by setting index to the ArrayList's size.
         //
+        /// <summary>Inserts the elements of a collection into the <see cref="T:System.Collections.ArrayList" /> at the specified index.</summary>
+        /// <param name="index">The zero-based index at which the new elements should be inserted. </param>
+        /// <param name="c">The <see cref="T:System.Collections.ICollection" /> whose elements should be inserted into the <see cref="T:System.Collections.ArrayList" />. The collection itself cannot be null, but it can contain elements that are null. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="c" /> is null. </exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero.-or- <paramref name="index" /> is greater than <see cref="P:System.Collections.ArrayList.Count" />. </exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only.-or- The <see cref="T:System.Collections.ArrayList" /> has a fixed size. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void InsertRange(int index, ICollection c)
         {
             if (c == null)
@@ -548,6 +704,10 @@ namespace System.Collections
         // This method uses the Array.LastIndexOf method to perform the
         // search.
         // 
+        /// <summary>Searches for the specified <see cref="T:System.Object" /> and returns the zero-based index of the last occurrence within the entire <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <returns>The zero-based index of the last occurrence of <paramref name="value" /> within the entire the <see cref="T:System.Collections.ArrayList" />, if found; otherwise, -1.</returns>
+        /// <param name="value">The <see cref="T:System.Object" /> to locate in the <see cref="T:System.Collections.ArrayList" />. The value can be null. </param>
+        /// <filterpriority>2</filterpriority>
         public virtual int LastIndexOf(Object value)
         {
             Contract.Ensures(Contract.Result<int>() < _size);
@@ -563,6 +723,12 @@ namespace System.Collections
         // This method uses the Array.LastIndexOf method to perform the
         // search.
         // 
+        /// <summary>Searches for the specified <see cref="T:System.Object" /> and returns the zero-based index of the last occurrence within the range of elements in the <see cref="T:System.Collections.ArrayList" /> that extends from the first element to the specified index.</summary>
+        /// <returns>The zero-based index of the last occurrence of <paramref name="value" /> within the range of elements in the <see cref="T:System.Collections.ArrayList" /> that extends from the first element to <paramref name="startIndex" />, if found; otherwise, -1.</returns>
+        /// <param name="value">The <see cref="T:System.Object" /> to locate in the <see cref="T:System.Collections.ArrayList" />. The value can be null. </param>
+        /// <param name="startIndex">The zero-based starting index of the backward search. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="startIndex" /> is outside the range of valid indexes for the <see cref="T:System.Collections.ArrayList" />. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual int LastIndexOf(Object value, int startIndex)
         {
             if (startIndex >= _size)
@@ -581,6 +747,13 @@ namespace System.Collections
         // This method uses the Array.LastIndexOf method to perform the
         // search.
         // 
+        /// <summary>Searches for the specified <see cref="T:System.Object" /> and returns the zero-based index of the last occurrence within the range of elements in the <see cref="T:System.Collections.ArrayList" /> that contains the specified number of elements and ends at the specified index.</summary>
+        /// <returns>The zero-based index of the last occurrence of <paramref name="value" /> within the range of elements in the <see cref="T:System.Collections.ArrayList" /> that contains <paramref name="count" /> number of elements and ends at <paramref name="startIndex" />, if found; otherwise, -1.</returns>
+        /// <param name="value">The <see cref="T:System.Object" /> to locate in the <see cref="T:System.Collections.ArrayList" />. The value can be null. </param>
+        /// <param name="startIndex">The zero-based starting index of the backward search. </param>
+        /// <param name="count">The number of elements in the section to search. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="startIndex" /> is outside the range of valid indexes for the <see cref="T:System.Collections.ArrayList" />.-or- <paramref name="count" /> is less than zero.-or- <paramref name="startIndex" /> and <paramref name="count" /> do not specify a valid section in the <see cref="T:System.Collections.ArrayList" />. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual int LastIndexOf(Object value, int startIndex, int count)
         {
             if (Count != 0 && (startIndex < 0 || count < 0))
@@ -602,6 +775,11 @@ namespace System.Collections
 #if FEATURE_NETCORE
         [FriendAccessAllowed]
 #endif
+        /// <summary>Returns a read-only <see cref="T:System.Collections.IList" /> wrapper.</summary>
+        /// <returns>A read-only <see cref="T:System.Collections.IList" /> wrapper around <paramref name="list" />.</returns>
+        /// <param name="list">The <see cref="T:System.Collections.IList" /> to wrap. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="list" /> is null. </exception>
+        /// <filterpriority>2</filterpriority>
         public static IList ReadOnly(IList list)
         {
             if (list == null)
@@ -613,6 +791,11 @@ namespace System.Collections
 
         // Returns a read-only ArrayList wrapper for the given ArrayList.
         //
+        /// <summary>Returns a read-only <see cref="T:System.Collections.ArrayList" /> wrapper.</summary>
+        /// <returns>A read-only <see cref="T:System.Collections.ArrayList" /> wrapper around <paramref name="list" />.</returns>
+        /// <param name="list">The <see cref="T:System.Collections.ArrayList" /> to wrap. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="list" /> is null. </exception>
+        /// <filterpriority>2</filterpriority>
         public static ArrayList ReadOnly(ArrayList list)
         {
             if (list == null)
@@ -625,6 +808,10 @@ namespace System.Collections
         // Removes the element at the given index. The size of the list is
         // decreased by one.
         // 
+        /// <summary>Removes the first occurrence of a specific object from the <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <param name="obj">The <see cref="T:System.Object" /> to remove from the <see cref="T:System.Collections.ArrayList" />. The value can be null. </param>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only.-or- The <see cref="T:System.Collections.ArrayList" /> has a fixed size. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual void Remove(Object obj)
         {
             Contract.Ensures(Count >= 0);
@@ -638,6 +825,11 @@ namespace System.Collections
         // Removes the element at the given index. The size of the list is
         // decreased by one.
         // 
+        /// <summary>Removes the element at the specified index of the <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <param name="index">The zero-based index of the element to remove. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero.-or- <paramref name="index" /> is equal to or greater than <see cref="P:System.Collections.ArrayList.Count" />. </exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only.-or- The <see cref="T:System.Collections.ArrayList" /> has a fixed size. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual void RemoveAt(int index)
         {
             if (index < 0 || index >= _size) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
@@ -656,6 +848,13 @@ namespace System.Collections
 
         // Removes a range of elements from this list.
         // 
+        /// <summary>Removes a range of elements from the <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <param name="index">The zero-based starting index of the range of elements to remove. </param>
+        /// <param name="count">The number of elements to remove. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero.-or- <paramref name="count" /> is less than zero. </exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="index" /> and <paramref name="count" /> do not denote a valid range of elements in the <see cref="T:System.Collections.ArrayList" />. </exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only.-or- The <see cref="T:System.Collections.ArrayList" /> has a fixed size. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void RemoveRange(int index, int count)
         {
             if (index < 0)
@@ -683,6 +882,12 @@ namespace System.Collections
 
         // Returns an IList that contains count copies of value.
         //
+        /// <summary>Returns an <see cref="T:System.Collections.ArrayList" /> whose elements are copies of the specified value.</summary>
+        /// <returns>An <see cref="T:System.Collections.ArrayList" /> with <paramref name="count" /> number of elements, all of which are copies of <paramref name="value" />.</returns>
+        /// <param name="value">The <see cref="T:System.Object" /> to copy multiple times in the new <see cref="T:System.Collections.ArrayList" />. The value can be null. </param>
+        /// <param name="count">The number of times <paramref name="value" /> should be copied. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="count" /> is less than zero. </exception>
+        /// <filterpriority>2</filterpriority>
         public static ArrayList Repeat(Object value, int count)
         {
             if (count < 0)
@@ -697,6 +902,9 @@ namespace System.Collections
         }
 
         // Reverses the elements in this list.
+        /// <summary>Reverses the order of the elements in the entire <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void Reverse()
         {
             Reverse(0, Count);
@@ -710,6 +918,13 @@ namespace System.Collections
         // This method uses the Array.Reverse method to reverse the
         // elements.
         // 
+        /// <summary>Reverses the order of the elements in the specified range.</summary>
+        /// <param name="index">The zero-based starting index of the range to reverse. </param>
+        /// <param name="count">The number of elements in the range to reverse. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero.-or- <paramref name="count" /> is less than zero. </exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="index" /> and <paramref name="count" /> do not denote a valid range of elements in the <see cref="T:System.Collections.ArrayList" />. </exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void Reverse(int index, int count)
         {
             if (index < 0)
@@ -726,6 +941,13 @@ namespace System.Collections
         // Sets the elements starting at the given index to the elements of the
         // given collection.
         //
+        /// <summary>Copies the elements of a collection over a range of elements in the <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <param name="index">The zero-based <see cref="T:System.Collections.ArrayList" /> index at which to start copying the elements of <paramref name="c" />. </param>
+        /// <param name="c">The <see cref="T:System.Collections.ICollection" /> whose elements to copy to the <see cref="T:System.Collections.ArrayList" />. The collection itself cannot be null, but it can contain elements that are null. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero.-or- <paramref name="index" /> plus the number of elements in <paramref name="c" /> is greater than <see cref="P:System.Collections.ArrayList.Count" />. </exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="c" /> is null. </exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void SetRange(int index, ICollection c)
         {
             if (c == null) throw new ArgumentNullException(nameof(c), SR.ArgumentNull_Collection);
@@ -740,6 +962,13 @@ namespace System.Collections
             }
         }
 
+        /// <summary>Returns an <see cref="T:System.Collections.ArrayList" /> which represents a subset of the elements in the source <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <returns>An <see cref="T:System.Collections.ArrayList" /> which represents a subset of the elements in the source <see cref="T:System.Collections.ArrayList" />.</returns>
+        /// <param name="index">The zero-based <see cref="T:System.Collections.ArrayList" /> index at which the range starts. </param>
+        /// <param name="count">The number of elements in the range. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero.-or- <paramref name="count" /> is less than zero. </exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="index" /> and <paramref name="count" /> do not denote a valid range of elements in the <see cref="T:System.Collections.ArrayList" />. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual ArrayList GetRange(int index, int count)
         {
             if (index < 0 || count < 0)
@@ -753,6 +982,9 @@ namespace System.Collections
 
         // Sorts the elements in this list.  Uses the default comparer and 
         // Array.Sort.
+        /// <summary>Sorts the elements in the entire <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual void Sort()
         {
             Sort(0, Count, Comparer.Default);
@@ -760,6 +992,12 @@ namespace System.Collections
 
         // Sorts the elements in this list.  Uses Array.Sort with the
         // provided comparer.
+        /// <summary>Sorts the elements in the entire <see cref="T:System.Collections.ArrayList" /> using the specified comparer.</summary>
+        /// <param name="comparer">The <see cref="T:System.Collections.IComparer" /> implementation to use when comparing elements.-or- A null reference (Nothing in Visual Basic) to use the <see cref="T:System.IComparable" /> implementation of each element. </param>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only. </exception>
+        /// <exception cref="T:System.InvalidOperationException">An error occurred while comparing two elements.</exception>
+        /// <exception cref="T:System.ArgumentException">null is passed for <paramref name="comparer" />, and the elements in the list do not implement <see cref="T:System.IComparable" />.</exception>
+        /// <filterpriority>1</filterpriority>
         public virtual void Sort(IComparer comparer)
         {
             Sort(0, Count, comparer);
@@ -773,6 +1011,15 @@ namespace System.Collections
         // 
         // This method uses the Array.Sort method to sort the elements.
         // 
+        /// <summary>Sorts the elements in a range of elements in <see cref="T:System.Collections.ArrayList" /> using the specified comparer.</summary>
+        /// <param name="index">The zero-based starting index of the range to sort. </param>
+        /// <param name="count">The length of the range to sort. </param>
+        /// <param name="comparer">The <see cref="T:System.Collections.IComparer" /> implementation to use when comparing elements.-or- A null reference (Nothing in Visual Basic) to use the <see cref="T:System.IComparable" /> implementation of each element. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero.-or- <paramref name="count" /> is less than zero. </exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="index" /> and <paramref name="count" /> do not specify a valid range in the <see cref="T:System.Collections.ArrayList" />. </exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only. </exception>
+        /// <exception cref="T:System.InvalidOperationException">An error occurred while comparing two elements.</exception>
+        /// <filterpriority>1</filterpriority>
         public virtual void Sort(int index, int count, IComparer comparer)
         {
             if (index < 0)
@@ -789,6 +1036,11 @@ namespace System.Collections
 
         // Returns a thread-safe wrapper around an IList.
         //
+        /// <summary>Returns an <see cref="T:System.Collections.IList" /> wrapper that is synchronized (thread safe).</summary>
+        /// <returns>An <see cref="T:System.Collections.IList" /> wrapper that is synchronized (thread safe).</returns>
+        /// <param name="list">The <see cref="T:System.Collections.IList" /> to synchronize. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="list" /> is null. </exception>
+        /// <filterpriority>2</filterpriority>
         public static IList Synchronized(IList list)
         {
             if (list == null)
@@ -800,6 +1052,11 @@ namespace System.Collections
 
         // Returns a thread-safe wrapper around a ArrayList.
         //
+        /// <summary>Returns an <see cref="T:System.Collections.ArrayList" /> wrapper that is synchronized (thread safe).</summary>
+        /// <returns>An <see cref="T:System.Collections.ArrayList" /> wrapper that is synchronized (thread safe).</returns>
+        /// <param name="list">The <see cref="T:System.Collections.ArrayList" /> to synchronize. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="list" /> is null. </exception>
+        /// <filterpriority>2</filterpriority>
         public static ArrayList Synchronized(ArrayList list)
         {
             if (list == null)
@@ -811,6 +1068,9 @@ namespace System.Collections
 
         // ToArray returns a new Object array containing the contents of the ArrayList.
         // This requires copying the ArrayList, which is an O(n) operation.
+        /// <summary>Copies the elements of the <see cref="T:System.Collections.ArrayList" /> to a new <see cref="T:System.Object" /> array.</summary>
+        /// <returns>An <see cref="T:System.Object" /> array containing copies of the elements of the <see cref="T:System.Collections.ArrayList" />.</returns>
+        /// <filterpriority>1</filterpriority>
         public virtual Object[] ToArray()
         {
             Contract.Ensures(Contract.Result<Object[]>() != null);
@@ -828,6 +1088,12 @@ namespace System.Collections
         // downcasting all elements.  This copy may fail and is an O(n) operation.
         // Internally, this implementation calls Array.Copy.
         //
+        /// <summary>Copies the elements of the <see cref="T:System.Collections.ArrayList" /> to a new array of the specified element type.</summary>
+        /// <returns>An array of the specified element type containing copies of the elements of the <see cref="T:System.Collections.ArrayList" />.</returns>
+        /// <param name="type">The element <see cref="T:System.Type" /> of the destination array to create and copy elements to.</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="type" /> is null. </exception>
+        /// <exception cref="T:System.InvalidCastException">The type of the source <see cref="T:System.Collections.ArrayList" /> cannot be cast automatically to the specified type. </exception>
+        /// <filterpriority>1</filterpriority>
         [SecuritySafeCritical]
         public virtual Array ToArray(Type type)
         {
@@ -849,6 +1115,9 @@ namespace System.Collections
         // list.Clear();
         // list.TrimToSize();
         // 
+        /// <summary>Sets the capacity to the actual number of elements in the <see cref="T:System.Collections.ArrayList" />.</summary>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.ArrayList" /> is read-only.-or- The <see cref="T:System.Collections.ArrayList" /> has a fixed size. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void TrimToSize()
         {
             Capacity = _size;

--- a/src/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveComparer.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveComparer.cs
@@ -16,16 +16,22 @@ using System.Diagnostics.Contracts;
 
 namespace System.Collections
 {
+    /// <summary>Compares two objects for equivalence, ignoring the case of strings.</summary>
+    /// <filterpriority>2</filterpriority>
     public class CaseInsensitiveComparer : IComparer
     {
         private CompareInfo _compareInfo;
         private static volatile CaseInsensitiveComparer s_InvariantCaseInsensitiveComparer;
 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.CaseInsensitiveComparer" /> class using the <see cref="P:System.Threading.Thread.CurrentCulture" /> of the current thread.</summary>
         public CaseInsensitiveComparer()
         {
             _compareInfo = CultureInfo.CurrentCulture.CompareInfo;
         }
 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.CaseInsensitiveComparer" /> class using the specified <see cref="T:System.Globalization.CultureInfo" />.</summary>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use for the new <see cref="T:System.Collections.CaseInsensitiveComparer" />. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="culture" /> is null. </exception>
         public CaseInsensitiveComparer(CultureInfo culture)
         {
             if (culture == null)
@@ -36,6 +42,10 @@ namespace System.Collections
             _compareInfo = culture.CompareInfo;
         }
 
+        /// <summary>Gets an instance of <see cref="T:System.Collections.CaseInsensitiveComparer" /> that is associated with the <see cref="P:System.Threading.Thread.CurrentCulture" /> of the current thread and that is always available.</summary>
+        /// <returns>An instance of <see cref="T:System.Collections.CaseInsensitiveComparer" /> that is associated with the <see cref="P:System.Threading.Thread.CurrentCulture" /> of the current thread.</returns>
+        /// <filterpriority>1</filterpriority>
+        /// <PermissionSet><IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode" />      </PermissionSet>
         public static CaseInsensitiveComparer Default
         {
             get
@@ -46,6 +56,10 @@ namespace System.Collections
             }
         }
 
+        /// <summary>Gets an instance of <see cref="T:System.Collections.CaseInsensitiveComparer" /> that is associated with <see cref="P:System.Globalization.CultureInfo.InvariantCulture" /> and that is always available.</summary>
+        /// <returns>An instance of <see cref="T:System.Collections.CaseInsensitiveComparer" /> that is associated with <see cref="P:System.Globalization.CultureInfo.InvariantCulture" />.</returns>
+        /// <filterpriority>1</filterpriority>
+        /// <PermissionSet><IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode" />      </PermissionSet>
         public static CaseInsensitiveComparer DefaultInvariant
         {
             get
@@ -67,6 +81,12 @@ namespace System.Collections
         // If a doesn't implement IComparable and b does, -(b.CompareTo(a)) is returned.
         // Otherwise an exception is thrown.
         // 
+        /// <summary>Performs a case-insensitive comparison of two objects of the same type and returns a value indicating whether one is less than, equal to, or greater than the other.</summary>
+        /// <returns>A signed integer that indicates the relative values of <paramref name="a" /> and <paramref name="b" />, as shown in the following table.Value Meaning Less than zero <paramref name="a" /> is less than <paramref name="b" />, with casing ignored. Zero <paramref name="a" /> equals <paramref name="b" />, with casing ignored. Greater than zero <paramref name="a" /> is greater than <paramref name="b" />, with casing ignored. </returns>
+        /// <param name="a">The first object to compare. </param>
+        /// <param name="b">The second object to compare. </param>
+        /// <exception cref="T:System.ArgumentException">Neither <paramref name="a" /> nor <paramref name="b" /> implements the <see cref="T:System.IComparable" /> interface.-or- <paramref name="a" /> and <paramref name="b" /> are of different types. </exception>
+        /// <filterpriority>2</filterpriority>
         public int Compare(Object a, Object b)
         {
             String sa = a as String;

--- a/src/System.Collections.NonGeneric/src/System/Collections/CollectionBase.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/CollectionBase.cs
@@ -15,21 +15,28 @@ using System.Diagnostics.Contracts;
 namespace System.Collections
 {
     // Useful base class for typed read/write collections where items derive from object
+    /// <summary>Provides the abstract base class for a strongly typed collection.</summary>
+    /// <filterpriority>2</filterpriority>
     public abstract class CollectionBase : IList
     {
         private ArrayList _list;
 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.CollectionBase" /> class with the default initial capacity.</summary>
         protected CollectionBase()
         {
             _list = new ArrayList();
         }
 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.CollectionBase" /> class with the specified capacity.</summary>
+        /// <param name="capacity">The number of elements that the new list can initially store.</param>
         protected CollectionBase(int capacity)
         {
             _list = new ArrayList(capacity);
         }
 
 
+        /// <summary>Gets an <see cref="T:System.Collections.ArrayList" /> containing the list of elements in the <see cref="T:System.Collections.CollectionBase" /> instance.</summary>
+        /// <returns>An <see cref="T:System.Collections.ArrayList" /> representing the <see cref="T:System.Collections.CollectionBase" /> instance itself.Retrieving the value of this property is an O(1) operation.</returns>
         protected ArrayList InnerList
         {
             get
@@ -38,11 +45,18 @@ namespace System.Collections
             }
         }
 
+        /// <summary>Gets an <see cref="T:System.Collections.IList" /> containing the list of elements in the <see cref="T:System.Collections.CollectionBase" /> instance.</summary>
+        /// <returns>An <see cref="T:System.Collections.IList" /> representing the <see cref="T:System.Collections.CollectionBase" /> instance itself.</returns>
         protected IList List
         {
             get { return (IList)this; }
         }
 
+        /// <summary>Gets or sets the number of elements that the <see cref="T:System.Collections.CollectionBase" /> can contain.</summary>
+        /// <returns>The number of elements that the <see cref="T:System.Collections.CollectionBase" /> can contain.</returns>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><see cref="P:System.Collections.CollectionBase.Capacity" /> is set to a value that is less than <see cref="P:System.Collections.CollectionBase.Count" />.</exception>
+        /// <exception cref="T:System.OutOfMemoryException">There is not enough memory available on the system.</exception>
+        /// <filterpriority>2</filterpriority>
         public int Capacity
         {
             get
@@ -56,6 +70,9 @@ namespace System.Collections
         }
 
 
+        /// <summary>Gets the number of elements contained in the <see cref="T:System.Collections.CollectionBase" /> instance. This property cannot be overridden.</summary>
+        /// <returns>The number of elements contained in the <see cref="T:System.Collections.CollectionBase" /> instance.Retrieving the value of this property is an O(1) operation.</returns>
+        /// <filterpriority>2</filterpriority>
         public int Count
         {
             get
@@ -64,6 +81,8 @@ namespace System.Collections
             }
         }
 
+        /// <summary>Removes all objects from the <see cref="T:System.Collections.CollectionBase" /> instance. This method cannot be overridden.</summary>
+        /// <filterpriority>2</filterpriority>
         public void Clear()
         {
             OnClear();
@@ -71,6 +90,10 @@ namespace System.Collections
             OnClearComplete();
         }
 
+        /// <summary>Removes the element at the specified index of the <see cref="T:System.Collections.CollectionBase" /> instance. This method is not overridable.</summary>
+        /// <param name="index">The zero-based index of the element to remove.</param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero.-or-<paramref name="index" /> is equal to or greater than <see cref="P:System.Collections.CollectionBase.Count" />.</exception>
+        /// <filterpriority>2</filterpriority>
         public void RemoveAt(int index)
         {
             if (index < 0 || index >= Count)
@@ -211,45 +234,73 @@ namespace System.Collections
             }
         }
 
+        /// <summary>Returns an enumerator that iterates through the <see cref="T:System.Collections.CollectionBase" /> instance.</summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> for the <see cref="T:System.Collections.CollectionBase" /> instance.</returns>
+        /// <filterpriority>2</filterpriority>
         public IEnumerator GetEnumerator()
         {
             return InnerList.GetEnumerator();
         }
 
+        /// <summary>Performs additional custom processes before setting a value in the <see cref="T:System.Collections.CollectionBase" /> instance.</summary>
+        /// <param name="index">The zero-based index at which <paramref name="oldValue" /> can be found.</param>
+        /// <param name="oldValue">The value to replace with <paramref name="newValue" />.</param>
+        /// <param name="newValue">The new value of the element at <paramref name="index" />.</param>
         protected virtual void OnSet(int index, Object oldValue, Object newValue)
         {
         }
 
+        /// <summary>Performs additional custom processes before inserting a new element into the <see cref="T:System.Collections.CollectionBase" /> instance.</summary>
+        /// <param name="index">The zero-based index at which to insert <paramref name="value" />.</param>
+        /// <param name="value">The new value of the element at <paramref name="index" />.</param>
         protected virtual void OnInsert(int index, Object value)
         {
         }
 
+        /// <summary>Performs additional custom processes when clearing the contents of the <see cref="T:System.Collections.CollectionBase" /> instance.</summary>
         protected virtual void OnClear()
         {
         }
 
+        /// <summary>Performs additional custom processes when removing an element from the <see cref="T:System.Collections.CollectionBase" /> instance.</summary>
+        /// <param name="index">The zero-based index at which <paramref name="value" /> can be found.</param>
+        /// <param name="value">The value of the element to remove from <paramref name="index" />.</param>
         protected virtual void OnRemove(int index, Object value)
         {
         }
 
+        /// <summary>Performs additional custom processes when validating a value.</summary>
+        /// <param name="value">The object to validate.</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="value" /> is null.</exception>
         protected virtual void OnValidate(Object value)
         {
             if (value == null) throw new ArgumentNullException(nameof(value));
             Contract.EndContractBlock();
         }
 
+        /// <summary>Performs additional custom processes after setting a value in the <see cref="T:System.Collections.CollectionBase" /> instance.</summary>
+        /// <param name="index">The zero-based index at which <paramref name="oldValue" /> can be found.</param>
+        /// <param name="oldValue">The value to replace with <paramref name="newValue" />.</param>
+        /// <param name="newValue">The new value of the element at <paramref name="index" />.</param>
         protected virtual void OnSetComplete(int index, Object oldValue, Object newValue)
         {
         }
 
+        /// <summary>Performs additional custom processes after inserting a new element into the <see cref="T:System.Collections.CollectionBase" /> instance.</summary>
+        /// <param name="index">The zero-based index at which to insert <paramref name="value" />.</param>
+        /// <param name="value">The new value of the element at <paramref name="index" />.</param>
         protected virtual void OnInsertComplete(int index, Object value)
         {
         }
 
+        /// <summary>Performs additional custom processes after clearing the contents of the <see cref="T:System.Collections.CollectionBase" /> instance.</summary>
         protected virtual void OnClearComplete()
         {
         }
 
+        /// <summary>Performs additional custom processes after removing an element from the <see cref="T:System.Collections.CollectionBase" /> instance.</summary>
+        /// <param name="index">The zero-based index at which <paramref name="value" /> can be found.</param>
+        /// <param name="value">The value of the element to remove from <paramref name="index" />.</param>
         protected virtual void OnRemoveComplete(int index, Object value)
         {
         }

--- a/src/System.Collections.NonGeneric/src/System/Collections/Comparer.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Comparer.cs
@@ -16,14 +16,23 @@ using System.Diagnostics.Contracts;
 
 namespace System.Collections
 {
+    /// <summary>Compares two objects for equivalence, where string comparisons are case-sensitive.</summary>
+    /// <filterpriority>2</filterpriority>
     public sealed class Comparer : IComparer
     {
         private CompareInfo _compareInfo;
+        /// <summary>Represents an instance of <see cref="T:System.Collections.Comparer" /> that is associated with the <see cref="P:System.Threading.Thread.CurrentCulture" /> of the current thread. This field is read-only.</summary>
+        /// <filterpriority>1</filterpriority>
         public static readonly Comparer Default = new Comparer(CultureInfo.CurrentCulture);
+        /// <summary>Represents an instance of <see cref="T:System.Collections.Comparer" /> that is associated with <see cref="P:System.Globalization.CultureInfo.InvariantCulture" />. This field is read-only.</summary>
+        /// <filterpriority>1</filterpriority>
         public static readonly Comparer DefaultInvariant = new Comparer(CultureInfo.InvariantCulture);
 
         private const string CompareInfoName = "CompareInfo";
 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Comparer" /> class using the specified <see cref="T:System.Globalization.CultureInfo" />.</summary>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use for the new <see cref="T:System.Collections.Comparer" />. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="culture" /> is null. </exception>
         public Comparer(CultureInfo culture)
         {
             if (culture == null)
@@ -40,6 +49,12 @@ namespace System.Collections
         // If a doesn't implement IComparable and b does, -(b.CompareTo(a)) is returned.
         // Otherwise an exception is thrown.
         // 
+        /// <summary>Performs a case-sensitive comparison of two objects of the same type and returns a value indicating whether one is less than, equal to, or greater than the other.</summary>
+        /// <returns>A signed integer that indicates the relative values of <paramref name="a" /> and <paramref name="b" />, as shown in the following table.Value Meaning Less than zero <paramref name="a" /> is less than <paramref name="b" />. Zero <paramref name="a" /> equals <paramref name="b" />. Greater than zero <paramref name="a" /> is greater than <paramref name="b" />. </returns>
+        /// <param name="a">The first object to compare. </param>
+        /// <param name="b">The second object to compare. </param>
+        /// <exception cref="T:System.ArgumentException">Neither <paramref name="a" /> nor <paramref name="b" /> implements the <see cref="T:System.IComparable" /> interface.-or- <paramref name="a" /> and <paramref name="b" /> are of different types and neither one can handle comparisons with the other. </exception>
+        /// <filterpriority>2</filterpriority>
         public int Compare(Object a, Object b)
         {
             if (a == b) return 0;

--- a/src/System.Collections.NonGeneric/src/System/Collections/DictionaryBase.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/DictionaryBase.cs
@@ -15,10 +15,14 @@
 namespace System.Collections
 {
     // Useful base class for typed read/write collections where items derive from object
+    /// <summary>Provides the abstract base class for a strongly typed collection of key/value pairs.</summary>
+    /// <filterpriority>2</filterpriority>
     public abstract class DictionaryBase : IDictionary
     {
         private Hashtable _hashtable;
 
+        /// <summary>Gets the list of elements contained in the <see cref="T:System.Collections.DictionaryBase" /> instance.</summary>
+        /// <returns>A <see cref="T:System.Collections.Hashtable" /> representing the <see cref="T:System.Collections.DictionaryBase" /> instance itself.</returns>
         protected Hashtable InnerHashtable
         {
             get
@@ -29,11 +33,16 @@ namespace System.Collections
             }
         }
 
+        /// <summary>Gets the list of elements contained in the <see cref="T:System.Collections.DictionaryBase" /> instance.</summary>
+        /// <returns>An <see cref="T:System.Collections.IDictionary" /> representing the <see cref="T:System.Collections.DictionaryBase" /> instance itself.</returns>
         protected IDictionary Dictionary
         {
             get { return (IDictionary)this; }
         }
 
+        /// <summary>Gets the number of elements contained in the <see cref="T:System.Collections.DictionaryBase" /> instance.</summary>
+        /// <returns>The number of elements contained in the <see cref="T:System.Collections.DictionaryBase" /> instance.</returns>
+        /// <filterpriority>2</filterpriority>
         public int Count
         {
             // to avoid newing inner list if no items are ever added
@@ -70,6 +79,14 @@ namespace System.Collections
             get { return InnerHashtable.Values; }
         }
 
+        /// <summary>Copies the <see cref="T:System.Collections.DictionaryBase" /> elements to a one-dimensional <see cref="T:System.Array" /> at the specified index.</summary>
+        /// <param name="array">The one-dimensional <see cref="T:System.Array" /> that is the destination of the <see cref="T:System.Collections.DictionaryEntry" /> objects copied from the <see cref="T:System.Collections.DictionaryBase" /> instance. The <see cref="T:System.Array" /> must have zero-based indexing. </param>
+        /// <param name="index">The zero-based index in <paramref name="array" /> at which copying begins. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="array" /> is null. </exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero. </exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="array" /> is multidimensional.-or- The number of elements in the source <see cref="T:System.Collections.DictionaryBase" /> is greater than the available space from <paramref name="index" /> to the end of the destination <paramref name="array" />. </exception>
+        /// <exception cref="T:System.InvalidCastException">The type of the source <see cref="T:System.Collections.DictionaryBase" /> cannot be cast automatically to the type of the destination <paramref name="array" />. </exception>
+        /// <filterpriority>2</filterpriority>
         public void CopyTo(Array array, int index)
         {
             InnerHashtable.CopyTo(array, index);
@@ -135,6 +152,8 @@ namespace System.Collections
             }
         }
 
+        /// <summary>Clears the contents of the <see cref="T:System.Collections.DictionaryBase" /> instance.</summary>
+        /// <filterpriority>2</filterpriority>
         public void Clear()
         {
             OnClear();
@@ -163,6 +182,9 @@ namespace System.Collections
             }
         }
 
+        /// <summary>Returns an <see cref="T:System.Collections.IDictionaryEnumerator" /> that iterates through the <see cref="T:System.Collections.DictionaryBase" /> instance.</summary>
+        /// <returns>An <see cref="T:System.Collections.IDictionaryEnumerator" /> for the <see cref="T:System.Collections.DictionaryBase" /> instance.</returns>
+        /// <filterpriority>2</filterpriority>
         public IDictionaryEnumerator GetEnumerator()
         {
             return InnerHashtable.GetEnumerator();
@@ -173,43 +195,72 @@ namespace System.Collections
             return InnerHashtable.GetEnumerator();
         }
 
+        /// <summary>Gets the element with the specified key and value in the <see cref="T:System.Collections.DictionaryBase" /> instance.</summary>
+        /// <returns>An <see cref="T:System.Object" /> containing the element with the specified key and value.</returns>
+        /// <param name="key">The key of the element to get. </param>
+        /// <param name="currentValue">The current value of the element associated with <paramref name="key" />. </param>
         protected virtual object OnGet(object key, object currentValue)
         {
             return currentValue;
         }
 
+        /// <summary>Performs additional custom processes before setting a value in the <see cref="T:System.Collections.DictionaryBase" /> instance.</summary>
+        /// <param name="key">The key of the element to locate. </param>
+        /// <param name="oldValue">The old value of the element associated with <paramref name="key" />. </param>
+        /// <param name="newValue">The new value of the element associated with <paramref name="key" />. </param>
         protected virtual void OnSet(object key, object oldValue, object newValue)
         {
         }
 
+        /// <summary>Performs additional custom processes before inserting a new element into the <see cref="T:System.Collections.DictionaryBase" /> instance.</summary>
+        /// <param name="key">The key of the element to insert. </param>
+        /// <param name="value">The value of the element to insert. </param>
         protected virtual void OnInsert(object key, object value)
         {
         }
 
+        /// <summary>Performs additional custom processes before clearing the contents of the <see cref="T:System.Collections.DictionaryBase" /> instance.</summary>
         protected virtual void OnClear()
         {
         }
 
+        /// <summary>Performs additional custom processes before removing an element from the <see cref="T:System.Collections.DictionaryBase" /> instance.</summary>
+        /// <param name="key">The key of the element to remove. </param>
+        /// <param name="value">The value of the element to remove. </param>
         protected virtual void OnRemove(object key, object value)
         {
         }
 
+        /// <summary>Performs additional custom processes when validating the element with the specified key and value.</summary>
+        /// <param name="key">The key of the element to validate. </param>
+        /// <param name="value">The value of the element to validate. </param>
         protected virtual void OnValidate(object key, object value)
         {
         }
 
+        /// <summary>Performs additional custom processes after setting a value in the <see cref="T:System.Collections.DictionaryBase" /> instance.</summary>
+        /// <param name="key">The key of the element to locate. </param>
+        /// <param name="oldValue">The old value of the element associated with <paramref name="key" />. </param>
+        /// <param name="newValue">The new value of the element associated with <paramref name="key" />. </param>
         protected virtual void OnSetComplete(object key, object oldValue, object newValue)
         {
         }
 
+        /// <summary>Performs additional custom processes after inserting a new element into the <see cref="T:System.Collections.DictionaryBase" /> instance.</summary>
+        /// <param name="key">The key of the element to insert. </param>
+        /// <param name="value">The value of the element to insert. </param>
         protected virtual void OnInsertComplete(object key, object value)
         {
         }
 
+        /// <summary>Performs additional custom processes after clearing the contents of the <see cref="T:System.Collections.DictionaryBase" /> instance.</summary>
         protected virtual void OnClearComplete()
         {
         }
 
+        /// <summary>Performs additional custom processes after removing an element from the <see cref="T:System.Collections.DictionaryBase" /> instance.</summary>
+        /// <param name="key">The key of the element to remove. </param>
+        /// <param name="value">The value of the element to remove. </param>
         protected virtual void OnRemoveComplete(object key, object value)
         {
         }

--- a/src/System.Collections.NonGeneric/src/System/Collections/Hashtable.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Hashtable.cs
@@ -52,6 +52,8 @@ namespace System.Collections
     // the Hashtable.  That hash function (and the equals method on the 
     // IEqualityComparer) would be used for all objects in the table.
     //
+    /// <summary>Represents a collection of key/value pairs that are organized based on the hash code of the key.To browse the .NET Framework source code for this type, see the Reference Source.</summary>
+    /// <filterpriority>1</filterpriority>
     [DebuggerTypeProxy(typeof(System.Collections.Hashtable.HashtableDebugView))]
     [DebuggerDisplay("Count = {Count}")]
     public class Hashtable : IDictionary
@@ -149,6 +151,9 @@ namespace System.Collections
         private IEqualityComparer _keycomparer;
         private Object _syncRoot;
 
+        /// <summary>Gets the <see cref="T:System.Collections.IEqualityComparer" /> to use for the <see cref="T:System.Collections.Hashtable" />.</summary>
+        /// <returns>The <see cref="T:System.Collections.IEqualityComparer" /> to use for the <see cref="T:System.Collections.Hashtable" />.</returns>
+        /// <exception cref="T:System.ArgumentException">The property is set to a value, but the hash table was created using an <see cref="T:System.Collections.IHashCodeProvider" /> and an <see cref="T:System.Collections.IComparer" />. </exception>
         protected IEqualityComparer EqualityComparer
         {
             get
@@ -165,6 +170,7 @@ namespace System.Collections
 
         // Constructs a new hashtable. The hashtable is created with an initial
         // capacity of zero and a load factor of 1.0.
+        /// <summary>Initializes a new, empty instance of the <see cref="T:System.Collections.Hashtable" /> class using the default initial capacity, load factor, hash code provider, and comparer.</summary>
         public Hashtable() : this(0, 1.0f)
         {
         }
@@ -176,6 +182,9 @@ namespace System.Collections
         // eliminate a number of resizing operations that would otherwise be
         // performed when elements are added to the hashtable.
         // 
+        /// <summary>Initializes a new, empty instance of the <see cref="T:System.Collections.Hashtable" /> class using the specified initial capacity, and the default load factor, hash code provider, and comparer.</summary>
+        /// <param name="capacity">The approximate number of elements that the <see cref="T:System.Collections.Hashtable" /> object can initially contain. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="capacity" /> is less than zero. </exception>
         public Hashtable(int capacity) : this(capacity, 1.0f)
         {
         }
@@ -191,6 +200,11 @@ namespace System.Collections
         // increased memory consumption. A load factor of 1.0 generally provides
         // the best balance between speed and size.
         // 
+        /// <summary>Initializes a new, empty instance of the <see cref="T:System.Collections.Hashtable" /> class using the specified initial capacity and load factor, and the default hash code provider and comparer.</summary>
+        /// <param name="capacity">The approximate number of elements that the <see cref="T:System.Collections.Hashtable" /> object can initially contain. </param>
+        /// <param name="loadFactor">A number in the range from 0.1 through 1.0 that is multiplied by the default value which provides the best performance. The result is the maximum ratio of elements to buckets. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="capacity" /> is less than zero.-or- <paramref name="loadFactor" /> is less than 0.1.-or- <paramref name="loadFactor" /> is greater than 1.0. </exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="capacity" /> is causing an overflow.</exception>
         public Hashtable(int capacity, float loadFactor)
         {
             if (capacity < 0)
@@ -216,15 +230,26 @@ namespace System.Collections
             Debug.Assert(_loadsize < hashsize, "Invalid hashtable loadsize!");
         }
 
+        /// <summary>Initializes a new, empty instance of the <see cref="T:System.Collections.Hashtable" /> class using the specified initial capacity, load factor, and <see cref="T:System.Collections.IEqualityComparer" /> object.</summary>
+        /// <param name="capacity">The approximate number of elements that the <see cref="T:System.Collections.Hashtable" /> object can initially contain. </param>
+        /// <param name="loadFactor">A number in the range from 0.1 through 1.0 that is multiplied by the default value which provides the best performance. The result is the maximum ratio of elements to buckets.</param>
+        /// <param name="equalityComparer">The <see cref="T:System.Collections.IEqualityComparer" /> object that defines the hash code provider and the comparer to use with the <see cref="T:System.Collections.Hashtable" />.-or- null to use the default hash code provider and the default comparer. The default hash code provider is each key's implementation of <see cref="M:System.Object.GetHashCode" /> and the default comparer is each key's implementation of <see cref="M:System.Object.Equals(System.Object)" />. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="capacity" /> is less than zero.-or- <paramref name="loadFactor" /> is less than 0.1.-or- <paramref name="loadFactor" /> is greater than 1.0. </exception>
         public Hashtable(int capacity, float loadFactor, IEqualityComparer equalityComparer) : this(capacity, loadFactor)
         {
             _keycomparer = equalityComparer;
         }
 
+        /// <summary>Initializes a new, empty instance of the <see cref="T:System.Collections.Hashtable" /> class using the default initial capacity and load factor, and the specified <see cref="T:System.Collections.IEqualityComparer" /> object.</summary>
+        /// <param name="equalityComparer">The <see cref="T:System.Collections.IEqualityComparer" /> object that defines the hash code provider and the comparer to use with the <see cref="T:System.Collections.Hashtable" /> object.-or- null to use the default hash code provider and the default comparer. The default hash code provider is each key's implementation of <see cref="M:System.Object.GetHashCode" /> and the default comparer is each key's implementation of <see cref="M:System.Object.Equals(System.Object)" />. </param>
         public Hashtable(IEqualityComparer equalityComparer) : this(0, 1.0f, equalityComparer)
         {
         }
 
+        /// <summary>Initializes a new, empty instance of the <see cref="T:System.Collections.Hashtable" /> class using the specified initial capacity and <see cref="T:System.Collections.IEqualityComparer" />, and the default load factor.</summary>
+        /// <param name="capacity">The approximate number of elements that the <see cref="T:System.Collections.Hashtable" /> object can initially contain. </param>
+        /// <param name="equalityComparer">The <see cref="T:System.Collections.IEqualityComparer" /> object that defines the hash code provider and the comparer to use with the <see cref="T:System.Collections.Hashtable" />.-or- null to use the default hash code provider and the default comparer. The default hash code provider is each key's implementation of <see cref="M:System.Object.GetHashCode" /> and the default comparer is each key's implementation of <see cref="M:System.Object.Equals(System.Object)" />. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="capacity" /> is less than zero. </exception>
         public Hashtable(int capacity, IEqualityComparer equalityComparer)
             : this(capacity, 1.0f, equalityComparer)
         {
@@ -233,6 +258,9 @@ namespace System.Collections
         // Constructs a new hashtable containing a copy of the entries in the given
         // dictionary. The hashtable is created with a load factor of 1.0.
         // 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Hashtable" /> class by copying the elements from the specified dictionary to the new <see cref="T:System.Collections.Hashtable" /> object. The new <see cref="T:System.Collections.Hashtable" /> object has an initial capacity equal to the number of elements copied, and uses the default load factor, hash code provider, and comparer.</summary>
+        /// <param name="d">The <see cref="T:System.Collections.IDictionary" /> object to copy to a new <see cref="T:System.Collections.Hashtable" /> object. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="d" /> is null. </exception>
         public Hashtable(IDictionary d) : this(d, 1.0f)
         {
         }
@@ -240,16 +268,31 @@ namespace System.Collections
         // Constructs a new hashtable containing a copy of the entries in the given
         // dictionary. The hashtable is created with the given load factor.
         // 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Hashtable" /> class by copying the elements from the specified dictionary to the new <see cref="T:System.Collections.Hashtable" /> object. The new <see cref="T:System.Collections.Hashtable" /> object has an initial capacity equal to the number of elements copied, and uses the specified load factor, and the default hash code provider and comparer.</summary>
+        /// <param name="d">The <see cref="T:System.Collections.IDictionary" /> object to copy to a new <see cref="T:System.Collections.Hashtable" /> object.</param>
+        /// <param name="loadFactor">A number in the range from 0.1 through 1.0 that is multiplied by the default value which provides the best performance. The result is the maximum ratio of elements to buckets.</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="d" /> is null. </exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="loadFactor" /> is less than 0.1.-or- <paramref name="loadFactor" /> is greater than 1.0. </exception>
         public Hashtable(IDictionary d, float loadFactor)
             : this(d, loadFactor, (IEqualityComparer)null)
         {
         }
 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Hashtable" /> class by copying the elements from the specified dictionary to a new <see cref="T:System.Collections.Hashtable" /> object. The new <see cref="T:System.Collections.Hashtable" /> object has an initial capacity equal to the number of elements copied, and uses the default load factor and the specified <see cref="T:System.Collections.IEqualityComparer" /> object.</summary>
+        /// <param name="d">The <see cref="T:System.Collections.IDictionary" /> object to copy to a new <see cref="T:System.Collections.Hashtable" /> object.</param>
+        /// <param name="equalityComparer">The <see cref="T:System.Collections.IEqualityComparer" /> object that defines the hash code provider and the comparer to use with the <see cref="T:System.Collections.Hashtable" />.-or- null to use the default hash code provider and the default comparer. The default hash code provider is each key's implementation of <see cref="M:System.Object.GetHashCode" /> and the default comparer is each key's implementation of <see cref="M:System.Object.Equals(System.Object)" />. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="d" /> is null. </exception>
         public Hashtable(IDictionary d, IEqualityComparer equalityComparer)
             : this(d, 1.0f, equalityComparer)
         {
         }
 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Hashtable" /> class by copying the elements from the specified dictionary to the new <see cref="T:System.Collections.Hashtable" /> object. The new <see cref="T:System.Collections.Hashtable" /> object has an initial capacity equal to the number of elements copied, and uses the specified load factor and <see cref="T:System.Collections.IEqualityComparer" /> object.</summary>
+        /// <param name="d">The <see cref="T:System.Collections.IDictionary" /> object to copy to a new <see cref="T:System.Collections.Hashtable" /> object.</param>
+        /// <param name="loadFactor">A number in the range from 0.1 through 1.0 that is multiplied by the default value which provides the best performance. The result is the maximum ratio of elements to buckets.</param>
+        /// <param name="equalityComparer">The <see cref="T:System.Collections.IEqualityComparer" /> object that defines the hash code provider and the comparer to use with the <see cref="T:System.Collections.Hashtable" />.-or- null to use the default hash code provider and the default comparer. The default hash code provider is each key's implementation of <see cref="M:System.Object.GetHashCode" /> and the default comparer is each key's implementation of <see cref="M:System.Object.Equals(System.Object)" />. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="d" /> is null. </exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="loadFactor" /> is less than 0.1.-or- <paramref name="loadFactor" /> is greater than 1.0. </exception>
         public Hashtable(IDictionary d, float loadFactor, IEqualityComparer equalityComparer)
             : this((d != null ? d.Count : 0), loadFactor, equalityComparer)
         {
@@ -300,12 +343,22 @@ namespace System.Collections
         // ArgumentException is thrown if the key is null or if the key is already
         // present in the hashtable.
         // 
+        /// <summary>Adds an element with the specified key and value into the <see cref="T:System.Collections.Hashtable" />.</summary>
+        /// <param name="key">The key of the element to add. </param>
+        /// <param name="value">The value of the element to add. The value can be null. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null. </exception>
+        /// <exception cref="T:System.ArgumentException">An element with the same key already exists in the <see cref="T:System.Collections.Hashtable" />. </exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Hashtable" /> is read-only.-or- The <see cref="T:System.Collections.Hashtable" /> has a fixed size. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual void Add(Object key, Object value)
         {
             Insert(key, value, true);
         }
 
         // Removes all entries from this hashtable.
+        /// <summary>Removes all elements from the <see cref="T:System.Collections.Hashtable" />.</summary>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Hashtable" /> is read-only. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual void Clear()
         {
             Debug.Assert(!_isWriterInProgress, "Race condition detected in usages of Hashtable - multiple threads appear to be writing to a Hashtable instance simultaneously!  Don't do that - use Hashtable.Synchronized.");
@@ -330,6 +383,9 @@ namespace System.Collections
         // Clone returns a virtually identical copy of this hash table.  This does
         // a shallow copy - the Objects in the table aren't cloned, only the references
         // to those Objects.
+        /// <summary>Creates a shallow copy of the <see cref="T:System.Collections.Hashtable" />.</summary>
+        /// <returns>A shallow copy of the <see cref="T:System.Collections.Hashtable" />.</returns>
+        /// <filterpriority>1</filterpriority>
         public virtual Object Clone()
         {
             bucket[] lbuckets = _buckets;
@@ -353,6 +409,11 @@ namespace System.Collections
         }
 
         // Checks if this hashtable contains the given key.
+        /// <summary>Determines whether the <see cref="T:System.Collections.Hashtable" /> contains a specific key.</summary>
+        /// <returns>true if the <see cref="T:System.Collections.Hashtable" /> contains an element with the specified key; otherwise, false.</returns>
+        /// <param name="key">The key to locate in the <see cref="T:System.Collections.Hashtable" />. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual bool Contains(Object key)
         {
             return ContainsKey(key);
@@ -361,6 +422,11 @@ namespace System.Collections
         // Checks if this hashtable contains an entry with the given key.  This is
         // an O(1) operation.
         // 
+        /// <summary>Determines whether the <see cref="T:System.Collections.Hashtable" /> contains a specific key.</summary>
+        /// <returns>true if the <see cref="T:System.Collections.Hashtable" /> contains an element with the specified key; otherwise, false.</returns>
+        /// <param name="key">The key to locate in the <see cref="T:System.Collections.Hashtable" />. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual bool ContainsKey(Object key)
         {
             if (key == null)
@@ -401,6 +467,10 @@ namespace System.Collections
         // search and is thus be substantially slower than the ContainsKey
         // method.
         // 
+        /// <summary>Determines whether the <see cref="T:System.Collections.Hashtable" /> contains a specific value.</summary>
+        /// <returns>true if the <see cref="T:System.Collections.Hashtable" /> contains an element with the specified <paramref name="value" />; otherwise, false.</returns>
+        /// <param name="value">The value to locate in the <see cref="T:System.Collections.Hashtable" />. The value can be null. </param>
+        /// <filterpriority>1</filterpriority>
         public virtual bool ContainsValue(Object value)
         {
             if (value == null)
@@ -463,6 +533,14 @@ namespace System.Collections
 
         // Copies the values in this hash table to an array at
         // a given index.  Note that this only copies values, and not keys.
+        /// <summary>Copies the <see cref="T:System.Collections.Hashtable" /> elements to a one-dimensional <see cref="T:System.Array" /> instance at the specified index.</summary>
+        /// <param name="array">The one-dimensional <see cref="T:System.Array" /> that is the destination of the <see cref="T:System.Collections.DictionaryEntry" /> objects copied from <see cref="T:System.Collections.Hashtable" />. The <see cref="T:System.Array" /> must have zero-based indexing. </param>
+        /// <param name="arrayIndex">The zero-based index in <paramref name="array" /> at which copying begins. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="array" /> is null. </exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="arrayIndex" /> is less than zero. </exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="array" /> is multidimensional.-or- The number of elements in the source <see cref="T:System.Collections.Hashtable" /> is greater than the available space from <paramref name="arrayIndex" /> to the end of the destination <paramref name="array" />. </exception>
+        /// <exception cref="T:System.InvalidCastException">The type of the source <see cref="T:System.Collections.Hashtable" /> cannot be cast automatically to the type of the destination <paramref name="array" />. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void CopyTo(Array array, int arrayIndex)
         {
             if (array == null)
@@ -521,6 +599,12 @@ namespace System.Collections
         // Returns the value associated with the given key. If an entry with the
         // given key is not found, the returned value is null.
         // 
+        /// <summary>Gets or sets the value associated with the specified key.</summary>
+        /// <returns>The value associated with the specified key. If the specified key is not found, attempting to get it returns null, and attempting to set it creates a new element using the specified key.</returns>
+        /// <param name="key">The key whose value to get or set. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null. </exception>
+        /// <exception cref="T:System.NotSupportedException">The property is set and the <see cref="T:System.Collections.Hashtable" /> is read-only.-or- The property is set, <paramref name="key" /> does not exist in the collection, and the <see cref="T:System.Collections.Hashtable" /> has a fixed size. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual Object this[Object key]
         {
             get
@@ -670,6 +754,9 @@ namespace System.Collections
         // in progress, the MoveNext and Current methods of the
         // enumerator will throw an exception.
         //
+        /// <summary>Returns an <see cref="T:System.Collections.IDictionaryEnumerator" /> that iterates through the <see cref="T:System.Collections.Hashtable" />.</summary>
+        /// <returns>An <see cref="T:System.Collections.IDictionaryEnumerator" /> for the <see cref="T:System.Collections.Hashtable" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual IDictionaryEnumerator GetEnumerator()
         {
             return new HashtableEnumerator(this, HashtableEnumerator.DictEntry);
@@ -678,6 +765,10 @@ namespace System.Collections
         // Internal method to get the hash code for an Object.  This will call
         // GetHashCode() on each object if you haven't provided an IHashCodeProvider
         // instance.  Otherwise, it calls hcp.GetHashCode(obj).
+        /// <summary>Returns the hash code for the specified key.</summary>
+        /// <returns>The hash code for <paramref name="key" />.</returns>
+        /// <param name="key">The <see cref="T:System.Object" /> for which a hash code is to be returned. </param>
+        /// <exception cref="T:System.NullReferenceException"><paramref name="key" /> is null. </exception>
         protected virtual int GetHash(Object key)
         {
             if (_keycomparer != null)
@@ -686,17 +777,26 @@ namespace System.Collections
         }
 
         // Is this Hashtable read-only?
+        /// <summary>Gets a value indicating whether the <see cref="T:System.Collections.Hashtable" /> is read-only.</summary>
+        /// <returns>true if the <see cref="T:System.Collections.Hashtable" /> is read-only; otherwise, false. The default is false.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual bool IsReadOnly
         {
             get { return false; }
         }
 
+        /// <summary>Gets a value indicating whether the <see cref="T:System.Collections.Hashtable" /> has a fixed size.</summary>
+        /// <returns>true if the <see cref="T:System.Collections.Hashtable" /> has a fixed size; otherwise, false. The default is false.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual bool IsFixedSize
         {
             get { return false; }
         }
 
         // Is this Hashtable synchronized?  See SyncRoot property
+        /// <summary>Gets a value indicating whether access to the <see cref="T:System.Collections.Hashtable" /> is synchronized (thread safe).</summary>
+        /// <returns>true if access to the <see cref="T:System.Collections.Hashtable" /> is synchronized (thread safe); otherwise, false. The default is false.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual bool IsSynchronized
         {
             get { return false; }
@@ -706,6 +806,11 @@ namespace System.Collections
         // instance in the constructor, this method will call comparer.Compare(item, key).
         // Otherwise, it will call item.Equals(key).
         // 
+        /// <summary>Compares a specific <see cref="T:System.Object" /> with a specific key in the <see cref="T:System.Collections.Hashtable" />.</summary>
+        /// <returns>true if <paramref name="item" /> and <paramref name="key" /> are equal; otherwise, false.</returns>
+        /// <param name="item">The <see cref="T:System.Object" /> to compare with <paramref name="key" />. </param>
+        /// <param name="key">The key in the <see cref="T:System.Collections.Hashtable" /> to compare with <paramref name="item" />. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="item" /> is null.-or- <paramref name="key" /> is null. </exception>
         protected virtual bool KeyEquals(Object item, Object key)
         {
             Debug.Assert(key != null, "key can't be null here!");
@@ -731,6 +836,9 @@ namespace System.Collections
         // to the hash table are reflected in this collection.  It is not
         // a static copy of all the keys in the hash table.
         // 
+        /// <summary>Gets an <see cref="T:System.Collections.ICollection" /> containing the keys in the <see cref="T:System.Collections.Hashtable" />.</summary>
+        /// <returns>An <see cref="T:System.Collections.ICollection" /> containing the keys in the <see cref="T:System.Collections.Hashtable" />.</returns>
+        /// <filterpriority>1</filterpriority>
         public virtual ICollection Keys
         {
             get
@@ -750,6 +858,9 @@ namespace System.Collections
         // to the hash table are reflected in this collection.  It is not
         // a static copy of all the keys in the hash table.
         // 
+        /// <summary>Gets an <see cref="T:System.Collections.ICollection" /> containing the values in the <see cref="T:System.Collections.Hashtable" />.</summary>
+        /// <returns>An <see cref="T:System.Collections.ICollection" /> containing the values in the <see cref="T:System.Collections.Hashtable" />.</returns>
+        /// <filterpriority>1</filterpriority>
         public virtual ICollection Values
         {
             get
@@ -940,6 +1051,11 @@ namespace System.Collections
         // key exists in the hashtable, it is removed. An ArgumentException is
         // thrown if the key is null.
         // 
+        /// <summary>Removes the element with the specified key from the <see cref="T:System.Collections.Hashtable" />.</summary>
+        /// <param name="key">The key of the element to remove. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null. </exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Hashtable" /> is read-only.-or- The <see cref="T:System.Collections.Hashtable" /> has a fixed size. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual void Remove(Object key)
         {
             if (key == null)
@@ -985,6 +1101,9 @@ namespace System.Collections
         }
 
         // Returns the object to synchronize on for this hash table.
+        /// <summary>Gets an object that can be used to synchronize access to the <see cref="T:System.Collections.Hashtable" />.</summary>
+        /// <returns>An object that can be used to synchronize access to the <see cref="T:System.Collections.Hashtable" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual Object SyncRoot
         {
             get
@@ -999,6 +1118,9 @@ namespace System.Collections
 
         // Returns the number of associations in this hashtable.
         // 
+        /// <summary>Gets the number of key/value pairs contained in the <see cref="T:System.Collections.Hashtable" />.</summary>
+        /// <returns>The number of key/value pairs contained in the <see cref="T:System.Collections.Hashtable" />.</returns>
+        /// <filterpriority>1</filterpriority>
         public virtual int Count
         {
             get { return _count; }
@@ -1006,6 +1128,11 @@ namespace System.Collections
 
         // Returns a thread-safe wrapper for a Hashtable.
         //
+        /// <summary>Returns a synchronized (thread-safe) wrapper for the <see cref="T:System.Collections.Hashtable" />.</summary>
+        /// <returns>A synchronized (thread-safe) wrapper for the <see cref="T:System.Collections.Hashtable" />.</returns>
+        /// <param name="table">The <see cref="T:System.Collections.Hashtable" /> to synchronize. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="table" /> is null. </exception>
+        /// <filterpriority>1</filterpriority>
         public static Hashtable Synchronized(Hashtable table)
         {
             if (table == null)

--- a/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
@@ -18,6 +18,8 @@ namespace System.Collections
 {
     // A simple Queue of objects.  Internally it is implemented as a circular
     // buffer, so Enqueue can be O(n).  Dequeue is O(1).
+    /// <summary>Represents a first-in, first-out collection of objects.</summary>
+    /// <filterpriority>1</filterpriority>
     [DebuggerTypeProxy(typeof(System.Collections.Queue.QueueDebugView))]
     [DebuggerDisplay("Count = {Count}")]
     public class Queue : ICollection
@@ -35,6 +37,7 @@ namespace System.Collections
 
         // Creates a queue with room for capacity objects. The default initial
         // capacity and grow factor are used.
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Queue" /> class that is empty, has the default initial capacity, and uses the default growth factor.</summary>
         public Queue()
             : this(32, (float)2.0)
         {
@@ -43,6 +46,9 @@ namespace System.Collections
         // Creates a queue with room for capacity objects. The default grow factor
         // is used.
         //
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Queue" /> class that is empty, has the specified initial capacity, and uses the default growth factor.</summary>
+        /// <param name="capacity">The initial number of elements that the <see cref="T:System.Collections.Queue" /> can contain. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="capacity" /> is less than zero. </exception>
         public Queue(int capacity)
             : this(capacity, (float)2.0)
         {
@@ -51,6 +57,10 @@ namespace System.Collections
         // Creates a queue with room for capacity objects. When full, the new
         // capacity is set to the old capacity * growFactor.
         //
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Queue" /> class that is empty, has the specified initial capacity, and uses the specified growth factor.</summary>
+        /// <param name="capacity">The initial number of elements that the <see cref="T:System.Collections.Queue" /> can contain. </param>
+        /// <param name="growFactor">The factor by which the capacity of the <see cref="T:System.Collections.Queue" /> is expanded. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="capacity" /> is less than zero.-or- <paramref name="growFactor" /> is less than 1.0 or greater than 10.0. </exception>
         public Queue(int capacity, float growFactor)
         {
             if (capacity < 0)
@@ -69,6 +79,9 @@ namespace System.Collections
         // Fills a Queue with the elements of an ICollection.  Uses the enumerator
         // to get each of the elements.
         //
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Queue" /> class that contains elements copied from the specified collection, has the same initial capacity as the number of elements copied, and uses the default growth factor.</summary>
+        /// <param name="col">The <see cref="T:System.Collections.ICollection" /> to copy elements from. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="col" /> is null. </exception>
         public Queue(ICollection col) : this((col == null ? 32 : col.Count))
         {
             if (col == null)
@@ -80,11 +93,17 @@ namespace System.Collections
         }
 
 
+        /// <summary>Gets the number of elements contained in the <see cref="T:System.Collections.Queue" />.</summary>
+        /// <returns>The number of elements contained in the <see cref="T:System.Collections.Queue" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual int Count
         {
             get { return _size; }
         }
 
+        /// <summary>Creates a shallow copy of the <see cref="T:System.Collections.Queue" />.</summary>
+        /// <returns>A shallow copy of the <see cref="T:System.Collections.Queue" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual Object Clone()
         {
             Queue q = new Queue(_size);
@@ -101,11 +120,17 @@ namespace System.Collections
             return q;
         }
 
+        /// <summary>Gets a value indicating whether access to the <see cref="T:System.Collections.Queue" /> is synchronized (thread safe).</summary>
+        /// <returns>true if access to the <see cref="T:System.Collections.Queue" /> is synchronized (thread safe); otherwise, false. The default is false.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual bool IsSynchronized
         {
             get { return false; }
         }
 
+        /// <summary>Gets an object that can be used to synchronize access to the <see cref="T:System.Collections.Queue" />.</summary>
+        /// <returns>An object that can be used to synchronize access to the <see cref="T:System.Collections.Queue" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual Object SyncRoot
         {
             get
@@ -119,6 +144,8 @@ namespace System.Collections
         }
 
         // Removes all Objects from the queue.
+        /// <summary>Removes all objects from the <see cref="T:System.Collections.Queue" />.</summary>
+        /// <filterpriority>2</filterpriority>
         public virtual void Clear()
         {
             if (_size != 0)
@@ -142,6 +169,14 @@ namespace System.Collections
         // CopyTo copies a collection into an Array, starting at a particular
         // index into the array.
         // 
+        /// <summary>Copies the <see cref="T:System.Collections.Queue" /> elements to an existing one-dimensional <see cref="T:System.Array" />, starting at the specified array index.</summary>
+        /// <param name="array">The one-dimensional <see cref="T:System.Array" /> that is the destination of the elements copied from <see cref="T:System.Collections.Queue" />. The <see cref="T:System.Array" /> must have zero-based indexing. </param>
+        /// <param name="index">The zero-based index in <paramref name="array" /> at which copying begins. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="array" /> is null. </exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero. </exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="array" /> is multidimensional.-or- The number of elements in the source <see cref="T:System.Collections.Queue" /> is greater than the available space from <paramref name="index" /> to the end of the destination <paramref name="array" />. </exception>
+        /// <exception cref="T:System.ArrayTypeMismatchException">The type of the source <see cref="T:System.Collections.Queue" /> cannot be cast automatically to the type of the destination <paramref name="array" />. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void CopyTo(Array array, int index)
         {
             if (array == null)
@@ -167,6 +202,9 @@ namespace System.Collections
 
         // Adds obj to the tail of the queue.
         //
+        /// <summary>Adds an object to the end of the <see cref="T:System.Collections.Queue" />.</summary>
+        /// <param name="obj">The object to add to the <see cref="T:System.Collections.Queue" />. The value can be null. </param>
+        /// <filterpriority>2</filterpriority>
         public virtual void Enqueue(Object obj)
         {
             if (_size == _array.Length)
@@ -188,6 +226,9 @@ namespace System.Collections
         // GetEnumerator returns an IEnumerator over this Queue.  This
         // Enumerator will support removing.
         // 
+        /// <summary>Returns an enumerator that iterates through the <see cref="T:System.Collections.Queue" />.</summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> for the <see cref="T:System.Collections.Queue" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual IEnumerator GetEnumerator()
         {
             return new QueueEnumerator(this);
@@ -195,6 +236,10 @@ namespace System.Collections
 
         // Removes the object at the head of the queue and returns it. If the queue
         // is empty, this method simply returns null.
+        /// <summary>Removes and returns the object at the beginning of the <see cref="T:System.Collections.Queue" />.</summary>
+        /// <returns>The object that is removed from the beginning of the <see cref="T:System.Collections.Queue" />.</returns>
+        /// <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Collections.Queue" /> is empty. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual Object Dequeue()
         {
             if (Count == 0)
@@ -212,6 +257,10 @@ namespace System.Collections
         // Returns the object at the head of the queue. The object remains in the
         // queue. If the queue is empty, this method throws an 
         // InvalidOperationException.
+        /// <summary>Returns the object at the beginning of the <see cref="T:System.Collections.Queue" /> without removing it.</summary>
+        /// <returns>The object at the beginning of the <see cref="T:System.Collections.Queue" />.</returns>
+        /// <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Collections.Queue" /> is empty. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual Object Peek()
         {
             if (Count == 0)
@@ -225,6 +274,11 @@ namespace System.Collections
         // class around the queue - the caller must not use references to the
         // original queue.
         // 
+        /// <summary>Returns a new <see cref="T:System.Collections.Queue" /> that wraps the original queue, and is thread safe.</summary>
+        /// <returns>A <see cref="T:System.Collections.Queue" /> wrapper that is synchronized (thread safe).</returns>
+        /// <param name="queue">The <see cref="T:System.Collections.Queue" /> to synchronize. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="queue" /> is null. </exception>
+        /// <filterpriority>2</filterpriority>
         public static Queue Synchronized(Queue queue)
         {
             if (queue == null)
@@ -237,6 +291,10 @@ namespace System.Collections
         // Equality is determined using obj.Equals().
         //
         // Exceptions: ArgumentNullException if obj == null.
+        /// <summary>Determines whether an element is in the <see cref="T:System.Collections.Queue" />.</summary>
+        /// <returns>true if <paramref name="obj" /> is found in the <see cref="T:System.Collections.Queue" />; otherwise, false.</returns>
+        /// <param name="obj">The <see cref="T:System.Object" /> to locate in the <see cref="T:System.Collections.Queue" />. The value can be null. </param>
+        /// <filterpriority>2</filterpriority>
         public virtual bool Contains(Object obj)
         {
             int index = _head;
@@ -268,6 +326,9 @@ namespace System.Collections
         // objects in the Queue, or an empty array if the queue is empty.
         // The order of elements in the array is first in to last in, the same
         // order produced by successive calls to Dequeue.
+        /// <summary>Copies the <see cref="T:System.Collections.Queue" /> elements to a new array.</summary>
+        /// <returns>A new array containing elements copied from the <see cref="T:System.Collections.Queue" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual Object[] ToArray()
         {
             if (_size == 0)
@@ -312,6 +373,9 @@ namespace System.Collections
             _version++;
         }
 
+        /// <summary>Sets the capacity to the actual number of elements in the <see cref="T:System.Collections.Queue" />.</summary>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Queue" /> is read-only.</exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void TrimToSize()
         {
             SetCapacity(_size);

--- a/src/System.Collections.NonGeneric/src/System/Collections/ReadOnlyCollectionBase.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/ReadOnlyCollectionBase.cs
@@ -15,10 +15,14 @@
 namespace System.Collections
 {
     // Useful base class for typed readonly collections where items derive from object
+    /// <summary>Provides the abstract base class for a strongly typed non-generic read-only collection.</summary>
+    /// <filterpriority>2</filterpriority>
     public abstract class ReadOnlyCollectionBase : ICollection
     {
         private ArrayList _list;
 
+        /// <summary>Gets the list of elements contained in the <see cref="T:System.Collections.ReadOnlyCollectionBase" /> instance.</summary>
+        /// <returns>An <see cref="T:System.Collections.ArrayList" /> representing the <see cref="T:System.Collections.ReadOnlyCollectionBase" /> instance itself.</returns>
         protected ArrayList InnerList
         {
             get
@@ -29,6 +33,9 @@ namespace System.Collections
             }
         }
 
+        /// <summary>Gets the number of elements contained in the <see cref="T:System.Collections.ReadOnlyCollectionBase" /> instance.</summary>
+        /// <returns>The number of elements contained in the <see cref="T:System.Collections.ReadOnlyCollectionBase" /> instance.Retrieving the value of this property is an O(1) operation.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual int Count
         {
             get { return InnerList.Count; }
@@ -49,6 +56,9 @@ namespace System.Collections
             InnerList.CopyTo(array, index);
         }
 
+        /// <summary>Returns an enumerator that iterates through the <see cref="T:System.Collections.ReadOnlyCollectionBase" /> instance.</summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> for the <see cref="T:System.Collections.ReadOnlyCollectionBase" /> instance.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual IEnumerator GetEnumerator()
         {
             return InnerList.GetEnumerator();

--- a/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
@@ -58,6 +58,8 @@ namespace System.Collections
     // has a constructor that allows a specific IComparer implementation to
     // be specified.
     // 
+    /// <summary>Represents a collection of key/value pairs that are sorted by the keys and are accessible by key and by index.</summary>
+    /// <filterpriority>1</filterpriority>
     [DebuggerTypeProxy(typeof(System.Collections.SortedList.SortedListDebugView))]
     [DebuggerDisplay("Count = {Count}")]
 #if FEATURE_CORECLR
@@ -82,11 +84,12 @@ namespace System.Collections
         // required. The elements of the sorted list are ordered according to the
         // IComparable interface, which must be implemented by the keys of
         // all entries added to the sorted list.
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.SortedList" /> class that is empty, has the default initial capacity, and is sorted according to the <see cref="T:System.IComparable" /> interface implemented by each key added to the <see cref="T:System.Collections.SortedList" /> object.</summary>
         public SortedList()
         {
             Init();
         }
-        
+
         private void Init()
         {
             _keys = Array.Empty<Object>();
@@ -102,6 +105,10 @@ namespace System.Collections
         // IComparable interface, which must be implemented by the keys of
         // all entries added to the sorted list.
         //
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.SortedList" /> class that is empty, has the specified initial capacity, and is sorted according to the <see cref="T:System.IComparable" /> interface implemented by each key added to the <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <param name="initialCapacity">The initial number of elements that the <see cref="T:System.Collections.SortedList" /> object can contain. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="initialCapacity" /> is less than zero. </exception>
+        /// <exception cref="T:System.OutOfMemoryException">There is not enough available memory to create a <see cref="T:System.Collections.SortedList" /> object with the specified <paramref name="initialCapacity" />.</exception>
         public SortedList(int initialCapacity)
         {
             if (initialCapacity < 0)
@@ -122,6 +129,8 @@ namespace System.Collections
         // interface, which in that case must be implemented by the keys of all
         // entries added to the sorted list.
         // 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.SortedList" /> class that is empty, has the default initial capacity, and is sorted according to the specified <see cref="T:System.Collections.IComparer" /> interface.</summary>
+        /// <param name="comparer">The <see cref="T:System.Collections.IComparer" /> implementation to use when comparing keys.-or- null to use the <see cref="T:System.IComparable" /> implementation of each key. </param>
         public SortedList(IComparer comparer)
             : this()
         {
@@ -137,6 +146,11 @@ namespace System.Collections
         // the IComparable interface, which in that case must be implemented
         // by the keys of all entries added to the sorted list.
         // 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.SortedList" /> class that is empty, has the specified initial capacity, and is sorted according to the specified <see cref="T:System.Collections.IComparer" /> interface.</summary>
+        /// <param name="comparer">The <see cref="T:System.Collections.IComparer" /> implementation to use when comparing keys.-or- null to use the <see cref="T:System.IComparable" /> implementation of each key. </param>
+        /// <param name="capacity">The initial number of elements that the <see cref="T:System.Collections.SortedList" /> object can contain. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="capacity" /> is less than zero. </exception>
+        /// <exception cref="T:System.OutOfMemoryException">There is not enough available memory to create a <see cref="T:System.Collections.SortedList" /> object with the specified <paramref name="capacity" />.</exception>
         public SortedList(IComparer comparer, int capacity)
             : this(comparer)
         {
@@ -149,6 +163,10 @@ namespace System.Collections
         // keys of all entries in the the given dictionary as well as keys
         // subsequently added to the sorted list.
         // 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.SortedList" /> class that contains elements copied from the specified dictionary, has the same initial capacity as the number of elements copied, and is sorted according to the <see cref="T:System.IComparable" /> interface implemented by each key.</summary>
+        /// <param name="d">The <see cref="T:System.Collections.IDictionary" /> implementation to copy to a new <see cref="T:System.Collections.SortedList" /> object.</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="d" /> is null. </exception>
+        /// <exception cref="T:System.InvalidCastException">One or more elements in <paramref name="d" /> do not implement the <see cref="T:System.IComparable" /> interface. </exception>
         public SortedList(IDictionary d)
             : this(d, null)
         {
@@ -162,6 +180,11 @@ namespace System.Collections
         // by the keys of all entries in the the given dictionary as well as keys
         // subsequently added to the sorted list.
         // 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.SortedList" /> class that contains elements copied from the specified dictionary, has the same initial capacity as the number of elements copied, and is sorted according to the specified <see cref="T:System.Collections.IComparer" /> interface.</summary>
+        /// <param name="d">The <see cref="T:System.Collections.IDictionary" /> implementation to copy to a new <see cref="T:System.Collections.SortedList" /> object.</param>
+        /// <param name="comparer">The <see cref="T:System.Collections.IComparer" /> implementation to use when comparing keys.-or- null to use the <see cref="T:System.IComparable" /> implementation of each key. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="d" /> is null. </exception>
+        /// <exception cref="T:System.InvalidCastException"><paramref name="comparer" /> is null, and one or more elements in <paramref name="d" /> do not implement the <see cref="T:System.IComparable" /> interface. </exception>
         public SortedList(IDictionary d, IComparer comparer)
             : this(comparer, (d != null ? d.Count : 0))
         {
@@ -184,6 +207,15 @@ namespace System.Collections
         // Adds an entry with the given key and value to this sorted list. An
         // ArgumentException is thrown if the key is already present in the sorted list.
         // 
+        /// <summary>Adds an element with the specified key and value to a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <param name="key">The key of the element to add. </param>
+        /// <param name="value">The value of the element to add. The value can be null. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null. </exception>
+        /// <exception cref="T:System.ArgumentException">An element with the specified <paramref name="key" /> already exists in the <see cref="T:System.Collections.SortedList" /> object.-or- The <see cref="T:System.Collections.SortedList" /> is set to use the <see cref="T:System.IComparable" /> interface, and <paramref name="key" /> does not implement the <see cref="T:System.IComparable" /> interface. </exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.SortedList" /> is read-only.-or- The <see cref="T:System.Collections.SortedList" /> has a fixed size. </exception>
+        /// <exception cref="T:System.OutOfMemoryException">There is not enough available memory to add the element to the <see cref="T:System.Collections.SortedList" />.</exception>
+        /// <exception cref="T:System.InvalidOperationException">The comparer throws an exception. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void Add(Object key, Object value)
         {
             if (key == null) throw new ArgumentNullException(nameof(key), SR.ArgumentNull_Key);
@@ -200,6 +232,11 @@ namespace System.Collections
         // of entries the list can contain before a reallocation of the internal
         // arrays is required.
         // 
+        /// <summary>Gets or sets the capacity of a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>The number of elements that the <see cref="T:System.Collections.SortedList" /> object can contain.</returns>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">The value assigned is less than the current number of elements in the <see cref="T:System.Collections.SortedList" /> object.</exception>
+        /// <exception cref="T:System.OutOfMemoryException">There is not enough memory available on the system.</exception>
+        /// <filterpriority>2</filterpriority>
         public virtual int Capacity
         {
             get
@@ -241,6 +278,9 @@ namespace System.Collections
 
         // Returns the number of entries in this sorted list.
         // 
+        /// <summary>Gets the number of elements contained in a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>The number of elements contained in the <see cref="T:System.Collections.SortedList" /> object.</returns>
+        /// <filterpriority>1</filterpriority>
         public virtual int Count
         {
             get
@@ -253,6 +293,9 @@ namespace System.Collections
         // method returns the same object as GetKeyList, but typed as an
         // ICollection instead of an IList.
         // 
+        /// <summary>Gets the keys in a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>An <see cref="T:System.Collections.ICollection" /> object containing the keys in the <see cref="T:System.Collections.SortedList" /> object.</returns>
+        /// <filterpriority>1</filterpriority>
         public virtual ICollection Keys
         {
             get
@@ -265,6 +308,9 @@ namespace System.Collections
         // method returns the same object as GetValueList, but typed as an
         // ICollection instead of an IList.
         // 
+        /// <summary>Gets the values in a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>An <see cref="T:System.Collections.ICollection" /> object containing the values in the <see cref="T:System.Collections.SortedList" /> object.</returns>
+        /// <filterpriority>1</filterpriority>
         public virtual ICollection Values
         {
             get
@@ -274,23 +320,35 @@ namespace System.Collections
         }
 
         // Is this SortedList read-only?
+        /// <summary>Gets a value indicating whether a <see cref="T:System.Collections.SortedList" /> object is read-only.</summary>
+        /// <returns>true if the <see cref="T:System.Collections.SortedList" /> object is read-only; otherwise, false. The default is false.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual bool IsReadOnly
         {
             get { return false; }
         }
 
+        /// <summary>Gets a value indicating whether a <see cref="T:System.Collections.SortedList" /> object has a fixed size.</summary>
+        /// <returns>true if the <see cref="T:System.Collections.SortedList" /> object has a fixed size; otherwise, false. The default is false.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual bool IsFixedSize
         {
             get { return false; }
         }
 
         // Is this SortedList synchronized (thread-safe)?
+        /// <summary>Gets a value indicating whether access to a <see cref="T:System.Collections.SortedList" /> object is synchronized (thread safe).</summary>
+        /// <returns>true if access to the <see cref="T:System.Collections.SortedList" /> object is synchronized (thread safe); otherwise, false. The default is false.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual bool IsSynchronized
         {
             get { return false; }
         }
 
         // Synchronization root for this object.
+        /// <summary>Gets an object that can be used to synchronize access to a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>An object that can be used to synchronize access to the <see cref="T:System.Collections.SortedList" /> object.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual Object SyncRoot
         {
             get
@@ -304,6 +362,9 @@ namespace System.Collections
         }
 
         // Removes all entries from this sorted list.
+        /// <summary>Removes all elements from a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.SortedList" /> object is read-only.-or- The <see cref="T:System.Collections.SortedList" /> has a fixed size. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual void Clear()
         {
             // clear does not change the capacity
@@ -316,6 +377,10 @@ namespace System.Collections
         // Makes a virtually identical copy of this SortedList.  This is a shallow 
         // copy.  IE, the Objects in the SortedList are not cloned - we copy the 
         // references to those objects.
+        /// <summary>Creates a shallow copy of a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>A shallow copy of the <see cref="T:System.Collections.SortedList" /> object.</returns>
+        /// <filterpriority>2</filterpriority>
+        /// <PermissionSet><IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode" />      </PermissionSet>
         public virtual Object Clone()
         {
             SortedList sl = new SortedList(_size);
@@ -331,6 +396,12 @@ namespace System.Collections
 
         // Checks if this sorted list contains an entry with the given key.
         // 
+        /// <summary>Determines whether a <see cref="T:System.Collections.SortedList" /> object contains a specific key.</summary>
+        /// <returns>true if the <see cref="T:System.Collections.SortedList" /> object contains an element with the specified <paramref name="key" />; otherwise, false.</returns>
+        /// <param name="key">The key to locate in the <see cref="T:System.Collections.SortedList" /> object. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null. </exception>
+        /// <exception cref="T:System.InvalidOperationException">The comparer throws an exception. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual bool Contains(Object key)
         {
             return IndexOfKey(key) >= 0;
@@ -338,6 +409,12 @@ namespace System.Collections
 
         // Checks if this sorted list contains an entry with the given key.
         // 
+        /// <summary>Determines whether a <see cref="T:System.Collections.SortedList" /> object contains a specific key.</summary>
+        /// <returns>true if the <see cref="T:System.Collections.SortedList" /> object contains an element with the specified <paramref name="key" />; otherwise, false.</returns>
+        /// <param name="key">The key to locate in the <see cref="T:System.Collections.SortedList" /> object.</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null. </exception>
+        /// <exception cref="T:System.InvalidOperationException">The comparer throws an exception. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual bool ContainsKey(Object key)
         {
             // Yes, this is a SPEC'ed duplicate of Contains().
@@ -350,12 +427,24 @@ namespace System.Collections
         // search and is substantially slower than the Contains
         // method.
         // 
+        /// <summary>Determines whether a <see cref="T:System.Collections.SortedList" /> object contains a specific value.</summary>
+        /// <returns>true if the <see cref="T:System.Collections.SortedList" /> object contains an element with the specified <paramref name="value" />; otherwise, false.</returns>
+        /// <param name="value">The value to locate in the <see cref="T:System.Collections.SortedList" /> object. The value can be null. </param>
+        /// <filterpriority>2</filterpriority>
         public virtual bool ContainsValue(Object value)
         {
             return IndexOfValue(value) >= 0;
         }
 
         // Copies the values in this SortedList to an array.
+        /// <summary>Copies <see cref="T:System.Collections.SortedList" /> elements to a one-dimensional <see cref="T:System.Array" /> object, starting at the specified index in the array.</summary>
+        /// <param name="array">The one-dimensional <see cref="T:System.Array" /> object that is the destination of the <see cref="T:System.Collections.DictionaryEntry" /> objects copied from <see cref="T:System.Collections.SortedList" />. The <see cref="T:System.Array" /> must have zero-based indexing. </param>
+        /// <param name="arrayIndex">The zero-based index in <paramref name="array" /> at which copying begins. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="array" /> is null. </exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="arrayIndex" /> is less than zero. </exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="array" /> is multidimensional.-or- The number of elements in the source <see cref="T:System.Collections.SortedList" /> object is greater than the available space from <paramref name="arrayIndex" /> to the end of the destination <paramref name="array" />. </exception>
+        /// <exception cref="T:System.InvalidCastException">The type of the source <see cref="T:System.Collections.SortedList" /> cannot be cast automatically to the type of the destination <paramref name="array" />. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void CopyTo(Array array, int arrayIndex)
         {
             if (array == null)
@@ -404,6 +493,11 @@ namespace System.Collections
 
         // Returns the value of the entry at the given index.
         // 
+        /// <summary>Gets the value at the specified index of a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>The value at the specified index of the <see cref="T:System.Collections.SortedList" /> object.</returns>
+        /// <param name="index">The zero-based index of the value to get. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is outside the range of valid indexes for the <see cref="T:System.Collections.SortedList" /> object. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual Object GetByIndex(int index)
         {
             if (index < 0 || index >= Count)
@@ -427,6 +521,9 @@ namespace System.Collections
         // the MoveNext and Remove methods
         // of the enumerator will throw an exception.
         //
+        /// <summary>Returns an <see cref="T:System.Collections.IDictionaryEnumerator" /> object that iterates through a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>An <see cref="T:System.Collections.IDictionaryEnumerator" /> object for the <see cref="T:System.Collections.SortedList" /> object.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual IDictionaryEnumerator GetEnumerator()
         {
             return new SortedListEnumerator(this, 0, _size, SortedListEnumerator.DictEntry);
@@ -434,6 +531,11 @@ namespace System.Collections
 
         // Returns the key of the entry at the given index.
         // 
+        /// <summary>Gets the key at the specified index of a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>The key at the specified index of the <see cref="T:System.Collections.SortedList" /> object.</returns>
+        /// <param name="index">The zero-based index of the key to get. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is outside the range of valid indexes for the <see cref="T:System.Collections.SortedList" /> object.</exception>
+        /// <filterpriority>2</filterpriority>
         public virtual Object GetKey(int index)
         {
             if (index < 0 || index >= Count) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
@@ -453,6 +555,9 @@ namespace System.Collections
         // Remove and RemoveRange methods or through an enumerator).
         // Null is an invalid key value.
         // 
+        /// <summary>Gets the keys in a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>An <see cref="T:System.Collections.IList" /> object containing the keys in the <see cref="T:System.Collections.SortedList" /> object.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual IList GetKeyList()
         {
             if (_keyList == null) _keyList = new KeyList(this);
@@ -470,6 +575,9 @@ namespace System.Collections
         // elements (through the Remove, RemoveRange, Set and
         // SetRange methods or through an enumerator).
         // 
+        /// <summary>Gets the values in a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>An <see cref="T:System.Collections.IList" /> object containing the values in the <see cref="T:System.Collections.SortedList" /> object.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual IList GetValueList()
         {
             if (_valueList == null) _valueList = new ValueList(this);
@@ -479,6 +587,14 @@ namespace System.Collections
         // Returns the value associated with the given key. If an entry with the
         // given key is not found, the returned value is null.
         // 
+        /// <summary>Gets and sets the value associated with a specific key in a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>The value associated with the <paramref name="key" /> parameter in the <see cref="T:System.Collections.SortedList" /> object, if <paramref name="key" /> is found; otherwise, null.</returns>
+        /// <param name="key">The key associated with the value to get or set. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null. </exception>
+        /// <exception cref="T:System.NotSupportedException">The property is set and the <see cref="T:System.Collections.SortedList" /> object is read-only.-or- The property is set, <paramref name="key" /> does not exist in the collection, and the <see cref="T:System.Collections.SortedList" /> has a fixed size. </exception>
+        /// <exception cref="T:System.OutOfMemoryException">There is not enough available memory to add the element to the <see cref="T:System.Collections.SortedList" />.</exception>
+        /// <exception cref="T:System.InvalidOperationException">The comparer throws an exception. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual Object this[Object key]
         {
             get
@@ -509,6 +625,12 @@ namespace System.Collections
         // the given key does not occur in this sorted list. Null is an invalid 
         // key value.
         // 
+        /// <summary>Returns the zero-based index of the specified key in a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>The zero-based index of the <paramref name="key" /> parameter, if <paramref name="key" /> is found in the <see cref="T:System.Collections.SortedList" /> object; otherwise, -1.</returns>
+        /// <param name="key">The key to locate in the <see cref="T:System.Collections.SortedList" /> object. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null. </exception>
+        /// <exception cref="T:System.InvalidOperationException">The comparer throws an exception. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual int IndexOfKey(Object key)
         {
             if (key == null)
@@ -524,6 +646,10 @@ namespace System.Collections
         // size of this sorted list. The elements of the list are compared to the
         // given value using the Object.Equals method.
         // 
+        /// <summary>Returns the zero-based index of the first occurrence of the specified value in a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>The zero-based index of the first occurrence of the <paramref name="value" /> parameter, if <paramref name="value" /> is found in the <see cref="T:System.Collections.SortedList" /> object; otherwise, -1.</returns>
+        /// <param name="value">The value to locate in the <see cref="T:System.Collections.SortedList" /> object. The value can be null. </param>
+        /// <filterpriority>1</filterpriority>
         public virtual int IndexOfValue(Object value)
         {
             return Array.IndexOf(_values, value, 0, _size);
@@ -547,6 +673,11 @@ namespace System.Collections
         // Removes the entry at the given index. The size of the sorted list is
         // decreased by one.
         // 
+        /// <summary>Removes the element at the specified index of a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <param name="index">The zero-based index of the element to remove. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is outside the range of valid indexes for the <see cref="T:System.Collections.SortedList" /> object. </exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.SortedList" /> is read-only.-or- The <see cref="T:System.Collections.SortedList" /> has a fixed size. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void RemoveAt(int index)
         {
             if (index < 0 || index >= Count) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
@@ -566,6 +697,11 @@ namespace System.Collections
         // key exists in the sorted list, it is removed. An ArgumentException is
         // thrown if the key is null.
         // 
+        /// <summary>Removes the element with the specified key from a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <param name="key">The key of the element to remove. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null. </exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.SortedList" /> object is read-only.-or- The <see cref="T:System.Collections.SortedList" /> has a fixed size. </exception>
+        /// <filterpriority>1</filterpriority>
         public virtual void Remove(Object key)
         {
             int i = IndexOfKey(key);
@@ -576,6 +712,11 @@ namespace System.Collections
         // Sets the value at an index to a given value.  The previous value of
         // the given entry is overwritten.
         // 
+        /// <summary>Replaces the value at a specific index in a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <param name="index">The zero-based index at which to save <paramref name="value" />. </param>
+        /// <param name="value">The <see cref="T:System.Object" /> to save into the <see cref="T:System.Collections.SortedList" /> object. The value can be null. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is outside the range of valid indexes for the <see cref="T:System.Collections.SortedList" /> object. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void SetByIndex(int index, Object value)
         {
             if (index < 0 || index >= Count) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
@@ -586,6 +727,12 @@ namespace System.Collections
 
         // Returns a thread-safe SortedList.
         //
+        /// <summary>Returns a synchronized (thread-safe) wrapper for a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <returns>A synchronized (thread-safe) wrapper for the <see cref="T:System.Collections.SortedList" /> object.</returns>
+        /// <param name="list">The <see cref="T:System.Collections.SortedList" /> object to synchronize. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="list" /> is null. </exception>
+        /// <filterpriority>1</filterpriority>
+        /// <PermissionSet><IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode" />      </PermissionSet>
         public static SortedList Synchronized(SortedList list)
         {
             if (list == null)
@@ -603,6 +750,9 @@ namespace System.Collections
         // sortedList.Clear();
         // sortedList.TrimToSize();
         // 
+        /// <summary>Sets the capacity to the actual number of elements in a <see cref="T:System.Collections.SortedList" /> object.</summary>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.SortedList" /> object is read-only.-or- The <see cref="T:System.Collections.SortedList" /> has a fixed size. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void TrimToSize()
         {
             Capacity = _size;

--- a/src/System.Collections.NonGeneric/src/System/Collections/Specialized/CollectionsUtil.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Specialized/CollectionsUtil.cs
@@ -13,23 +13,37 @@
 
 namespace System.Collections.Specialized
 {
+    /// <summary>Creates collections that ignore the case in strings.</summary>
     public class CollectionsUtil
     {
+        /// <summary>Creates a new case-insensitive instance of the <see cref="T:System.Collections.Hashtable" /> class with the default initial capacity.</summary>
+        /// <returns>A new case-insensitive instance of the <see cref="T:System.Collections.Hashtable" /> class with the default initial capacity.</returns>
+        /// <PermissionSet><IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode" />      </PermissionSet>
         public static Hashtable CreateCaseInsensitiveHashtable()
         {
             return new Hashtable(StringComparer.CurrentCultureIgnoreCase);
         }
 
+        /// <summary>Creates a new case-insensitive instance of the <see cref="T:System.Collections.Hashtable" /> class with the specified initial capacity.</summary>
+        /// <returns>A new case-insensitive instance of the <see cref="T:System.Collections.Hashtable" /> class with the specified initial capacity.</returns>
+        /// <param name="capacity">The approximate number of entries that the <see cref="T:System.Collections.Hashtable" /> can initially contain. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="capacity" /> is less than zero. </exception>
         public static Hashtable CreateCaseInsensitiveHashtable(int capacity)
         {
             return new Hashtable(capacity, StringComparer.CurrentCultureIgnoreCase);
         }
 
+        /// <summary>Copies the entries from the specified dictionary to a new case-insensitive instance of the <see cref="T:System.Collections.Hashtable" /> class with the same initial capacity as the number of entries copied.</summary>
+        /// <returns>A new case-insensitive instance of the <see cref="T:System.Collections.Hashtable" /> class containing the entries from the specified <see cref="T:System.Collections.IDictionary" />.</returns>
+        /// <param name="d">The <see cref="T:System.Collections.IDictionary" /> to copy to a new case-insensitive <see cref="T:System.Collections.Hashtable" />. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="d" /> is null. </exception>
         public static Hashtable CreateCaseInsensitiveHashtable(IDictionary d)
         {
             return new Hashtable(d, StringComparer.CurrentCultureIgnoreCase);
         }
 
+        /// <summary>Creates a new instance of the <see cref="T:System.Collections.SortedList" /> class that ignores the case of strings.</summary>
+        /// <returns>A new instance of the <see cref="T:System.Collections.SortedList" /> class that ignores the case of strings.</returns>
         public static SortedList CreateCaseInsensitiveSortedList()
         {
             return new SortedList(CaseInsensitiveComparer.Default);

--- a/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
@@ -20,6 +20,8 @@ namespace System.Collections
 {
     // A simple stack of objects.  Internally it is implemented as an array,
     // so Push can be O(n).  Pop is O(1).
+    /// <summary>Represents a simple last-in-first-out (LIFO) non-generic collection of objects.</summary>
+    /// <filterpriority>1</filterpriority>
     [DebuggerTypeProxy(typeof(System.Collections.Stack.StackDebugView))]
     [DebuggerDisplay("Count = {Count}")]
     public class Stack : ICollection
@@ -32,6 +34,7 @@ namespace System.Collections
 
         private const int _defaultCapacity = 10;
 
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Stack" /> class that is empty and has the default initial capacity.</summary>
         public Stack()
         {
             _array = new Object[_defaultCapacity];
@@ -41,6 +44,9 @@ namespace System.Collections
 
         // Create a stack with a specific initial capacity.  The initial capacity
         // must be a non-negative number.
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Stack" /> class that is empty and has the specified initial capacity or the default initial capacity, whichever is greater.</summary>
+        /// <param name="initialCapacity">The initial number of elements that the <see cref="T:System.Collections.Stack" /> can contain. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="initialCapacity" /> is less than zero. </exception>
         public Stack(int initialCapacity)
         {
             if (initialCapacity < 0)
@@ -56,6 +62,9 @@ namespace System.Collections
         // Fills a Stack with the contents of a particular collection.  The items are
         // pushed onto the stack in the same order they are read by the enumerator.
         //
+        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Stack" /> class that contains elements copied from the specified collection and has the same initial capacity as the number of elements copied.</summary>
+        /// <param name="col">The <see cref="T:System.Collections.ICollection" /> to copy elements from. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="col" /> is null. </exception>
         public Stack(ICollection col) : this((col == null ? 32 : col.Count))
         {
             if (col == null)
@@ -66,6 +75,9 @@ namespace System.Collections
                 Push(en.Current);
         }
 
+        /// <summary>Gets the number of elements contained in the <see cref="T:System.Collections.Stack" />.</summary>
+        /// <returns>The number of elements contained in the <see cref="T:System.Collections.Stack" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual int Count
         {
             get
@@ -75,11 +87,17 @@ namespace System.Collections
             }
         }
 
+        /// <summary>Gets a value indicating whether access to the <see cref="T:System.Collections.Stack" /> is synchronized (thread safe).</summary>
+        /// <returns>true, if access to the <see cref="T:System.Collections.Stack" /> is synchronized (thread safe); otherwise, false. The default is false.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual bool IsSynchronized
         {
             get { return false; }
         }
 
+        /// <summary>Gets an object that can be used to synchronize access to the <see cref="T:System.Collections.Stack" />.</summary>
+        /// <returns>An <see cref="T:System.Object" /> that can be used to synchronize access to the <see cref="T:System.Collections.Stack" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual Object SyncRoot
         {
             get
@@ -93,6 +111,8 @@ namespace System.Collections
         }
 
         // Removes all Objects from the Stack.
+        /// <summary>Removes all objects from the <see cref="T:System.Collections.Stack" />.</summary>
+        /// <filterpriority>2</filterpriority>
         public virtual void Clear()
         {
             Array.Clear(_array, 0, _size); // Don't need to doc this but we clear the elements so that the gc can reclaim the references.
@@ -100,6 +120,9 @@ namespace System.Collections
             _version++;
         }
 
+        /// <summary>Creates a shallow copy of the <see cref="T:System.Collections.Stack" />.</summary>
+        /// <returns>A shallow copy of the <see cref="T:System.Collections.Stack" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual Object Clone()
         {
             Contract.Ensures(Contract.Result<Object>() != null);
@@ -111,6 +134,10 @@ namespace System.Collections
             return s;
         }
 
+        /// <summary>Determines whether an element is in the <see cref="T:System.Collections.Stack" />.</summary>
+        /// <returns>true, if <paramref name="obj" /> is found in the <see cref="T:System.Collections.Stack" />; otherwise, false.</returns>
+        /// <param name="obj">The <see cref="T:System.Object" /> to locate in the <see cref="T:System.Collections.Stack" />. The value can be null. </param>
+        /// <filterpriority>2</filterpriority>
         public virtual bool Contains(Object obj)
         {
             int count = _size;
@@ -131,6 +158,14 @@ namespace System.Collections
         }
 
         // Copies the stack into an array.
+        /// <summary>Copies the <see cref="T:System.Collections.Stack" /> to an existing one-dimensional <see cref="T:System.Array" />, starting at the specified array index.</summary>
+        /// <param name="array">The one-dimensional <see cref="T:System.Array" /> that is the destination of the elements copied from <see cref="T:System.Collections.Stack" />. The <see cref="T:System.Array" /> must have zero-based indexing. </param>
+        /// <param name="index">The zero-based index in <paramref name="array" /> at which copying begins. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="array" /> is null. </exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index" /> is less than zero. </exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="array" /> is multidimensional.-or- The number of elements in the source <see cref="T:System.Collections.Stack" /> is greater than the available space from <paramref name="index" /> to the end of the destination <paramref name="array" />. </exception>
+        /// <exception cref="T:System.InvalidCastException">The type of the source <see cref="T:System.Collections.Stack" /> cannot be cast automatically to the type of the destination <paramref name="array" />. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual void CopyTo(Array array, int index)
         {
             if (array == null)
@@ -164,6 +199,9 @@ namespace System.Collections
         }
 
         // Returns an IEnumerator for this Stack.
+        /// <summary>Returns an <see cref="T:System.Collections.IEnumerator" /> for the <see cref="T:System.Collections.Stack" />.</summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> for the <see cref="T:System.Collections.Stack" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual IEnumerator GetEnumerator()
         {
             Contract.Ensures(Contract.Result<IEnumerator>() != null);
@@ -172,6 +210,10 @@ namespace System.Collections
 
         // Returns the top object on the stack without removing it.  If the stack
         // is empty, Peek throws an InvalidOperationException.
+        /// <summary>Returns the object at the top of the <see cref="T:System.Collections.Stack" /> without removing it.</summary>
+        /// <returns>The <see cref="T:System.Object" /> at the top of the <see cref="T:System.Collections.Stack" />.</returns>
+        /// <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Collections.Stack" /> is empty. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual Object Peek()
         {
             if (_size == 0)
@@ -182,6 +224,10 @@ namespace System.Collections
 
         // Pops an item from the top of the stack.  If the stack is empty, Pop
         // throws an InvalidOperationException.
+        /// <summary>Removes and returns the object at the top of the <see cref="T:System.Collections.Stack" />.</summary>
+        /// <returns>The <see cref="T:System.Object" /> removed from the top of the <see cref="T:System.Collections.Stack" />.</returns>
+        /// <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Collections.Stack" /> is empty. </exception>
+        /// <filterpriority>2</filterpriority>
         public virtual Object Pop()
         {
             if (_size == 0)
@@ -196,6 +242,9 @@ namespace System.Collections
 
         // Pushes an item to the top of the stack.
         // 
+        /// <summary>Inserts an object at the top of the <see cref="T:System.Collections.Stack" />.</summary>
+        /// <param name="obj">The <see cref="T:System.Object" /> to push onto the <see cref="T:System.Collections.Stack" />. The value can be null. </param>
+        /// <filterpriority>2</filterpriority>
         public virtual void Push(Object obj)
         {
             //Contract.Ensures(Count == Contract.OldValue(Count) + 1);
@@ -211,6 +260,11 @@ namespace System.Collections
 
         // Returns a synchronized Stack.
         //
+        /// <summary>Returns a synchronized (thread safe) wrapper for the <see cref="T:System.Collections.Stack" />.</summary>
+        /// <returns>A synchronized wrapper around the <see cref="T:System.Collections.Stack" />.</returns>
+        /// <param name="stack">The <see cref="T:System.Collections.Stack" /> to synchronize. </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="stack" /> is null. </exception>
+        /// <filterpriority>2</filterpriority>
         public static Stack Synchronized(Stack stack)
         {
             if (stack == null)
@@ -222,6 +276,9 @@ namespace System.Collections
 
 
         // Copies the Stack to an array, in the same order Pop would return the items.
+        /// <summary>Copies the <see cref="T:System.Collections.Stack" /> to a new array.</summary>
+        /// <returns>A new array containing copies of the elements of the <see cref="T:System.Collections.Stack" />.</returns>
+        /// <filterpriority>2</filterpriority>
         public virtual Object[] ToArray()
         {
             Contract.Ensures(Contract.Result<Object[]>() != null);


### PR DESCRIPTION
PR'd on top of my fork so we don't create noise on the main repo.

Here's what the output looks like for a small assembly like `System.Collections.NonGeneric`.  As you can see, there's some work that'll be needed:
- Auditing for changes to method signatures
- Merging the inserted `///` comments with the existing `//` comments to make sure the most up-to-date comments are displayed
- Potential cleanup/reformatting of `///` comments depending on how we want them to be presented in the source

/cc @joshfree @Priya91 @stephentoub @mairaw
